### PR TITLE
[WIP] Adding Migration Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,8 @@
   },
   "require-dev": {
     "orchestra/testbench": "~3.5",
-    "phpunit/phpunit": "~6.0"
+    "phpunit/phpunit": "~6.0",
+    "mockery/mockery": "^1.2"
   },
   "autoload": {
     "psr-4": {

--- a/src/Colopl/Spanner/Console/BaseCommand.php
+++ b/src/Colopl/Spanner/Console/BaseCommand.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+use Illuminate\Console\Command;
+
+class BaseCommand extends Command
+{
+    /**
+     * Get all of the migration paths.
+     *
+     * @return array
+     */
+    protected function getMigrationPaths()
+    {
+        // Here, we will check to see if a path option has been defined. If it has we will
+        // use the path relative to the root of the installation folder so our database
+        // migrations may be run for any customized path from within the application.
+        if ($this->input->hasOption('path') && $this->option('path')) {
+            return collect($this->option('path'))->map(function ($path) {
+                return ! $this->usingRealPath()
+                    ? $this->laravel->basePath().'/'.$path
+                    : $path;
+            })->all();
+        }
+
+        return array_merge(
+            $this->migrator->paths(), [$this->getMigrationPath()]
+        );
+    }
+
+    /**
+     * Determine if the given path(s) are pre-resolved "real" paths.
+     *
+     * @return bool
+     */
+    protected function usingRealPath()
+    {
+        return $this->input->hasOption('realpath') && $this->option('realpath');
+    }
+
+    /**
+     * Get the path to the migration directory.
+     *
+     * @return string
+     */
+    protected function getMigrationPath()
+    {
+        return $this->laravel->databasePath().DIRECTORY_SEPARATOR.'migrations';
+    }
+}

--- a/src/Colopl/Spanner/Console/InstallCommand.php
+++ b/src/Colopl/Spanner/Console/InstallCommand.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+use Illuminate\Console\Command;
+use Symfony\Component\Console\Input\InputOption;
+use Colopl\Spanner\Migrations\MigrationRepositoryInterface;
+
+class InstallCommand extends Command
+{
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'spanner:migrate:install';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create the migration repository';
+
+    /**
+     * The repository instance.
+     *
+     * @var \Illuminate\Database\Migrations\MigrationRepositoryInterface
+     */
+    protected $repository;
+
+    /**
+     * Create a new migration install command instance.
+     *
+     * @param  \Colopl\Spanner\Migrations\MigrationRepositoryInterface  $repository
+     * @return void
+     */
+    public function __construct(MigrationRepositoryInterface $repository)
+    {
+        parent::__construct();
+
+        $this->repository = $repository;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->repository->setSource($this->input->getOption('database'));
+
+        $this->repository->createRepository();
+
+        $this->info('Migration table created successfully.');
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+        ];
+    }
+}

--- a/src/Colopl/Spanner/Console/MigrateCommand.php
+++ b/src/Colopl/Spanner/Console/MigrateCommand.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+use Illuminate\Console\ConfirmableTrait;
+use Colopl\Spanner\Migrations\Migrator;
+
+class MigrateCommand extends BaseCommand
+{
+    use ConfirmableTrait;
+
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'spanner:migrate {--database= : The database connection to use}
+                {--force : Force the operation to run when in production}
+                {--path= : The path to the migrations files to be executed}
+                {--realpath : Indicate any provided migration file paths are pre-resolved absolute paths}
+                {--pretend : Dump the SQL queries that would be run}
+                {--seed : Indicates if the seed task should be re-run}
+                {--step : Force the migrations to be run so they can be rolled back individually}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Run the database migrations';
+
+    /**
+     * The migrator instance.
+     *
+     * @var \Colopl\Spanner\Migrations\Migrator
+     */
+    protected $migrator;
+
+    /**
+     * Create a new migration command instance.
+     *
+     * @param  \Colopl\Spanner\Migrations\Migrator  $migrator
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct();
+
+        $this->migrator = $migrator;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $this->prepareDatabase();
+
+        // Next, we will check to see if a path option has been defined. If it has
+        // we will use the path relative to the root of this installation folder
+        // so that migrations may be run for any path within the applications.
+        $this->migrator->setOutput($this->output)
+            ->run($this->getMigrationPaths(), [
+                'pretend' => $this->option('pretend'),
+                'step' => $this->option('step'),
+            ]);
+
+        // Finally, if the "seed" option has been given, we will re-run the database
+        // seed task to re-populate the database, which is convenient when adding
+        // a migration and a seed at the same time, as it is only this command.
+        if ($this->option('seed') && ! $this->option('pretend')) {
+            $this->call('db:seed', ['--force' => true]);
+        }
+    }
+
+    /**
+     * Prepare the migration database for running.
+     *
+     * @return void
+     */
+    protected function prepareDatabase()
+    {
+        $this->migrator->setConnection($this->option('database'));
+
+        if (! $this->migrator->repositoryExists()) {
+            $this->call('migrate:install', array_filter([
+                '--database' => $this->option('database'),
+            ]));
+        }
+    }
+}

--- a/src/Colopl/Spanner/Console/ResetCommand.php
+++ b/src/Colopl/Spanner/Console/ResetCommand.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+use Illuminate\Console\ConfirmableTrait;
+use Colopl\Spanner\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
+
+class ResetCommand extends BaseCommand
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'spanner:migrate:reset';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rollback all database migrations';
+
+    /**
+     * The migrator instance.
+     *
+     * @var \Colopl\Spanner\Migrations\Migrator
+     */
+    protected $migrator;
+
+    /**
+     * Create a new migration rollback command instance.
+     *
+     * @param  \Colopl\Spanner\Migrations\Migrator  $migrator
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct();
+
+        $this->migrator = $migrator;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $this->migrator->setConnection($this->option('database'));
+
+        // First, we'll make sure that the migration table actually exists before we
+        // start trying to rollback and re-run all of the migrations. If it's not
+        // present we'll just bail out with an info message for the developers.
+        if (! $this->migrator->repositoryExists()) {
+            return $this->comment('Migration table not found.');
+        }
+
+        $this->migrator->setOutput($this->output)->reset(
+            $this->getMigrationPaths(), $this->option('pretend')
+        );
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+
+            ['path', null, InputOption::VALUE_OPTIONAL | InputOption::VALUE_IS_ARRAY, 'The path(s) to the migrations files to be executed'],
+
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+
+            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
+        ];
+    }
+}

--- a/src/Colopl/Spanner/Console/RollbackCommand.php
+++ b/src/Colopl/Spanner/Console/RollbackCommand.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+use Illuminate\Console\ConfirmableTrait;
+use Colopl\Spanner\Migrations\Migrator;
+use Symfony\Component\Console\Input\InputOption;
+
+class RollbackCommand extends BaseCommand
+{
+    use ConfirmableTrait;
+
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'spanner:migrate:rollback';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Rollback the last database migration';
+
+    /**
+     * The migrator instance.
+     *
+     * @var \Colopl\Spanner\Migrations\Migrator
+     */
+    protected $migrator;
+
+    /**
+     * Create a new migration rollback command instance.
+     *
+     * @param  \Colopl\Spanner\Migrations\Migrator  $migrator
+     * @return void
+     */
+    public function __construct(Migrator $migrator)
+    {
+        parent::__construct();
+
+        $this->migrator = $migrator;
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        if (! $this->confirmToProceed()) {
+            return;
+        }
+
+        $this->migrator->setConnection($this->option('database'));
+
+        $this->migrator->setOutput($this->output)->rollback(
+            $this->getMigrationPaths(), [
+                'pretend' => $this->option('pretend'),
+                'step' => (int) $this->option('step'),
+            ]
+        );
+    }
+
+    /**
+     * Get the console command options.
+     *
+     * @return array
+     */
+    protected function getOptions()
+    {
+        return [
+            ['database', null, InputOption::VALUE_OPTIONAL, 'The database connection to use'],
+
+            ['force', null, InputOption::VALUE_NONE, 'Force the operation to run when in production'],
+
+            ['path', null, InputOption::VALUE_OPTIONAL, 'The path to the migrations files to be executed'],
+
+            ['realpath', null, InputOption::VALUE_NONE, 'Indicate any provided migration file paths are pre-resolved absolute paths'],
+
+            ['pretend', null, InputOption::VALUE_NONE, 'Dump the SQL queries that would be run'],
+
+            ['step', null, InputOption::VALUE_OPTIONAL, 'The number of migrations to be reverted'],
+        ];
+    }
+}

--- a/src/Colopl/Spanner/Migrations/DatabaseMigrationRepository.php
+++ b/src/Colopl/Spanner/Migrations/DatabaseMigrationRepository.php
@@ -1,0 +1,213 @@
+<?php
+
+namespace Colopl\Spanner\Migrations;
+
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+use Ramsey\Uuid\Uuid;
+
+class DatabaseMigrationRepository implements MigrationRepositoryInterface
+{
+    /**
+     * The database connection resolver instance.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
+
+    /**
+     * The name of the migration table.
+     *
+     * @var string
+     */
+    protected $table;
+
+    /**
+     * The name of the database connection to use.
+     *
+     * @var string
+     */
+    protected $connection;
+
+    /**
+     * Create a new database migration repository instance.
+     *
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  string  $table
+     * @return void
+     */
+    public function __construct(Resolver $resolver, $table)
+    {
+        $this->table = $table;
+        $this->resolver = $resolver;
+    }
+
+    /**
+     * Get the completed migrations.
+     *
+     * @return array
+     */
+    public function getRan()
+    {
+        return $this->table()
+            ->orderBy('batch', 'asc')
+            ->orderBy('migration', 'asc')
+            ->pluck('migration')->all();
+    }
+
+    /**
+     * Get list of migrations.
+     *
+     * @param  int  $steps
+     * @return array
+     */
+    public function getMigrations($steps)
+    {
+        $query = $this->table()->where('batch', '>=', '1');
+
+        return $query->orderBy('batch', 'desc')
+            ->orderBy('migration', 'desc')
+            ->take($steps)->get()->all();
+    }
+
+    /**
+     * Get the last migration batch.
+     *
+     * @return array
+     */
+    public function getLast()
+    {
+        $query = $this->table()->where('batch', $this->getLastBatchNumber());
+
+        return $query->orderBy('migration', 'desc')->get()->all();
+    }
+
+    /**
+     * Get the completed migrations with their batch numbers.
+     *
+     * @return array
+     */
+    public function getMigrationBatches()
+    {
+        return $this->table()
+            ->orderBy('batch', 'asc')
+            ->orderBy('migration', 'asc')
+            ->pluck('batch', 'migration')->all();
+    }
+
+    /**
+     * Log that a migration was run.
+     *
+     * @param  string  $file
+     * @param  int  $batch
+     * @return void
+     */
+    public function log($file, $batch)
+    {
+        $record = ['id' => Uuid::uuid4(), 'migration' => $file, 'batch' => $batch];
+
+        $this->table()->insert($record);
+    }
+
+    /**
+     * Remove a migration from the log.
+     *
+     * @param  object  $migration
+     * @return void
+     */
+    public function delete($migration)
+    {
+        $this->table()->where('migration', $migration->migration)->delete();
+    }
+
+    /**
+     * Get the next migration batch number.
+     *
+     * @return int
+     */
+    public function getNextBatchNumber()
+    {
+        return $this->getLastBatchNumber() + 1;
+    }
+
+    /**
+     * Get the last migration batch number.
+     *
+     * @return int
+     */
+    public function getLastBatchNumber()
+    {
+        return $this->table()->max('batch');
+    }
+
+    /**
+     * Create the migration repository data store.
+     *
+     * @return void
+     */
+    public function createRepository()
+    {
+        $schema = $this->getConnection()->getSchemaBuilder();
+
+        $schema->create($this->table, function ($table) {
+            // The migrations table is responsible for keeping track of which of the
+            // migrations have actually run for the application. We'll create the
+            // table to hold the migration file's path as well as the batch ID.
+            $table->uuid('id')->primary();
+            $table->string('migration');
+            $table->integer('batch');
+        });
+    }
+
+    /**
+     * Determine if the migration repository exists.
+     *
+     * @return bool
+     */
+    public function repositoryExists()
+    {
+        $schema = $this->getConnection()->getSchemaBuilder();
+
+        return $schema->hasTable($this->table);
+    }
+
+    /**
+     * Get a query builder for the migration table.
+     *
+     * @return \Illuminate\Database\Query\Builder
+     */
+    protected function table()
+    {
+        return $this->getConnection()->table($this->table)->useWritePdo();
+    }
+
+    /**
+     * Get the connection resolver instance.
+     *
+     * @return \Illuminate\Database\ConnectionResolverInterface
+     */
+    public function getConnectionResolver()
+    {
+        return $this->resolver;
+    }
+
+    /**
+     * Resolve the database connection instance.
+     *
+     * @return \Illuminate\Database\Connection
+     */
+    public function getConnection()
+    {
+        return $this->resolver->connection($this->connection);
+    }
+
+    /**
+     * Set the information source to gather data.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setSource($name)
+    {
+        $this->connection = $name;
+    }
+}

--- a/src/Colopl/Spanner/Migrations/DatabaseMigrationRepository.php
+++ b/src/Colopl/Spanner/Migrations/DatabaseMigrationRepository.php
@@ -97,9 +97,10 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
     /**
      * Log that a migration was run.
      *
-     * @param  string  $file
-     * @param  int  $batch
+     * @param  string $file
+     * @param  int $batch
      * @return void
+     * @throws \Exception
      */
     public function log($file, $batch)
     {

--- a/src/Colopl/Spanner/Migrations/DatabaseMigrationRepository.php
+++ b/src/Colopl/Spanner/Migrations/DatabaseMigrationRepository.php
@@ -103,7 +103,7 @@ class DatabaseMigrationRepository implements MigrationRepositoryInterface
      */
     public function log($file, $batch)
     {
-        $record = ['id' => Uuid::uuid4(), 'migration' => $file, 'batch' => $batch];
+        $record = ['id' => Uuid::uuid4()->toString(), 'migration' => $file, 'batch' => $batch];
 
         $this->table()->insert($record);
     }

--- a/src/Colopl/Spanner/Migrations/MigrationRepositoryInterface.php
+++ b/src/Colopl/Spanner/Migrations/MigrationRepositoryInterface.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Colopl\Spanner\Migrations;
+
+interface MigrationRepositoryInterface
+{
+    /**
+     * Get the completed migrations.
+     *
+     * @return array
+     */
+    public function getRan();
+
+    /**
+     * Get list of migrations.
+     *
+     * @param  int  $steps
+     * @return array
+     */
+    public function getMigrations($steps);
+
+    /**
+     * Get the last migration batch.
+     *
+     * @return array
+     */
+    public function getLast();
+
+    /**
+     * Get the completed migrations with their batch numbers.
+     *
+     * @return array
+     */
+    public function getMigrationBatches();
+
+    /**
+     * Log that a migration was run.
+     *
+     * @param  string  $file
+     * @param  int  $batch
+     * @return void
+     */
+    public function log($file, $batch);
+
+    /**
+     * Remove a migration from the log.
+     *
+     * @param  object  $migration
+     * @return void
+     */
+    public function delete($migration);
+
+    /**
+     * Get the next migration batch number.
+     *
+     * @return int
+     */
+    public function getNextBatchNumber();
+
+    /**
+     * Create the migration repository data store.
+     *
+     * @return void
+     */
+    public function createRepository();
+
+    /**
+     * Determine if the migration repository exists.
+     *
+     * @return bool
+     */
+    public function repositoryExists();
+
+    /**
+     * Set the information source to gather data.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setSource($name);
+}

--- a/src/Colopl/Spanner/Migrations/Migrator.php
+++ b/src/Colopl/Spanner/Migrations/Migrator.php
@@ -1,0 +1,594 @@
+<?php
+
+namespace Colopl\Spanner\Migrations;
+
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
+use Illuminate\Support\Collection;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Database\ConnectionResolverInterface as Resolver;
+
+class Migrator
+{
+    /**
+     * The migration repository implementation.
+     *
+     * @var \Colopl\Spanner\Migrations\MigrationRepositoryInterface
+     */
+    protected $repository;
+
+    /**
+     * The filesystem instance.
+     *
+     * @var \Illuminate\Filesystem\Filesystem
+     */
+    protected $files;
+
+    /**
+     * The connection resolver instance.
+     *
+     * @var \Illuminate\Database\ConnectionResolverInterface
+     */
+    protected $resolver;
+
+    /**
+     * The name of the default connection.
+     *
+     * @var string
+     */
+    protected $connection;
+
+    /**
+     * The paths to all of the migration files.
+     *
+     * @var array
+     */
+    protected $paths = [];
+
+    /**
+     * The output interface implementation.
+     *
+     * @var \Illuminate\Console\OutputStyle
+     */
+    protected $output;
+
+    /**
+     * Create a new migrator instance.
+     *
+     * @param  \Colopl\Spanner\Migrations\MigrationRepositoryInterface  $repository
+     * @param  \Illuminate\Database\ConnectionResolverInterface  $resolver
+     * @param  \Illuminate\Filesystem\Filesystem  $files
+     * @return void
+     */
+    public function __construct(MigrationRepositoryInterface $repository,
+                                Resolver $resolver,
+                                Filesystem $files)
+    {
+        $this->files = $files;
+        $this->resolver = $resolver;
+        $this->repository = $repository;
+    }
+
+    /**
+     * Run the pending migrations at a given path.
+     *
+     * @param  array|string  $paths
+     * @param  array  $options
+     * @return array
+     */
+    public function run($paths = [], array $options = [])
+    {
+        $this->notes = [];
+
+        // Once we grab all of the migration files for the path, we will compare them
+        // against the migrations that have already been run for this package then
+        // run each of the outstanding migrations against a database connection.
+        $files = $this->getMigrationFiles($paths);
+
+        $this->requireFiles($migrations = $this->pendingMigrations(
+            $files, $this->repository->getRan()
+        ));
+
+        // Once we have all these migrations that are outstanding we are ready to run
+        // we will go ahead and run them "up". This will execute each migration as
+        // an operation against a database. Then we'll return this list of them.
+        $this->runPending($migrations, $options);
+
+        return $migrations;
+    }
+
+    /**
+     * Get the migration files that have not yet run.
+     *
+     * @param  array  $files
+     * @param  array  $ran
+     * @return array
+     */
+    protected function pendingMigrations($files, $ran)
+    {
+        return Collection::make($files)
+            ->reject(function ($file) use ($ran) {
+                return in_array($this->getMigrationName($file), $ran);
+            })->values()->all();
+    }
+
+    /**
+     * Run an array of migrations.
+     *
+     * @param  array  $migrations
+     * @param  array  $options
+     * @return void
+     */
+    public function runPending(array $migrations, array $options = [])
+    {
+        // First we will just make sure that there are any migrations to run. If there
+        // aren't, we will just make a note of it to the developer so they're aware
+        // that all of the migrations have been run against this database system.
+        if (count($migrations) === 0) {
+            $this->note('<info>Nothing to migrate.</info>');
+
+            return;
+        }
+
+        // Next, we will get the next batch number for the migrations so we can insert
+        // correct batch number in the database migrations repository when we store
+        // each migration's execution. We will also extract a few of the options.
+        $batch = $this->repository->getNextBatchNumber();
+
+        $pretend = $options['pretend'] ?? false;
+
+        $step = $options['step'] ?? false;
+
+        // Once we have the array of migrations, we will spin through them and run the
+        // migrations "up" so the changes are made to the databases. We'll then log
+        // that the migration was run so we don't repeat it next time we execute.
+        foreach ($migrations as $file) {
+            $this->runUp($file, $batch, $pretend);
+
+            if ($step) {
+                $batch++;
+            }
+        }
+    }
+
+    /**
+     * Run "up" a migration instance.
+     *
+     * @param  string  $file
+     * @param  int     $batch
+     * @param  bool    $pretend
+     * @return void
+     */
+    protected function runUp($file, $batch, $pretend)
+    {
+        // First we will resolve a "real" instance of the migration class from this
+        // migration file name. Once we have the instances we can run the actual
+        // command such as "up" or "down", or we can just simulate the action.
+        $migration = $this->resolve(
+            $name = $this->getMigrationName($file)
+        );
+
+        if ($pretend) {
+            return $this->pretendToRun($migration, 'up');
+        }
+
+        $this->note("<comment>Migrating:</comment> {$name}");
+
+        $this->runMigration($migration, 'up');
+
+        // Once we have run a migrations class, we will log that it was run in this
+        // repository so that we don't try to run it next time we do a migration
+        // in the application. A migration repository keeps the migrate order.
+        $this->repository->log($name, $batch);
+
+        $this->note("<info>Migrated:</info>  {$name}");
+    }
+
+    /**
+     * Rollback the last migration operation.
+     *
+     * @param  array|string $paths
+     * @param  array  $options
+     * @return array
+     */
+    public function rollback($paths = [], array $options = [])
+    {
+        $this->notes = [];
+
+        // We want to pull in the last batch of migrations that ran on the previous
+        // migration operation. We'll then reverse those migrations and run each
+        // of them "down" to reverse the last migration "operation" which ran.
+        $migrations = $this->getMigrationsForRollback($options);
+
+        if (count($migrations) === 0) {
+            $this->note('<info>Nothing to rollback.</info>');
+
+            return [];
+        }
+
+        return $this->rollbackMigrations($migrations, $paths, $options);
+    }
+
+    /**
+     * Get the migrations for a rollback operation.
+     *
+     * @param  array  $options
+     * @return array
+     */
+    protected function getMigrationsForRollback(array $options)
+    {
+        if (($steps = $options['step'] ?? 0) > 0) {
+            return $this->repository->getMigrations($steps);
+        }
+
+        return $this->repository->getLast();
+    }
+
+    /**
+     * Rollback the given migrations.
+     *
+     * @param  array  $migrations
+     * @param  array|string  $paths
+     * @param  array  $options
+     * @return array
+     */
+    protected function rollbackMigrations(array $migrations, $paths, array $options)
+    {
+        $rolledBack = [];
+
+        $this->requireFiles($files = $this->getMigrationFiles($paths));
+
+        // Next we will run through all of the migrations and call the "down" method
+        // which will reverse each migration in order. This getLast method on the
+        // repository already returns these migration's names in reverse order.
+        foreach ($migrations as $migration) {
+            $migration = (object) $migration;
+
+            if (! $file = Arr::get($files, $migration->migration)) {
+                $this->note("<fg=red>Migration not found:</> {$migration->migration}");
+
+                continue;
+            }
+
+            $rolledBack[] = $file;
+
+            $this->runDown(
+                $file, $migration,
+                $options['pretend'] ?? false
+            );
+        }
+
+        return $rolledBack;
+    }
+
+    /**
+     * Rolls all of the currently applied migrations back.
+     *
+     * @param  array|string $paths
+     * @param  bool  $pretend
+     * @return array
+     */
+    public function reset($paths = [], $pretend = false)
+    {
+        $this->notes = [];
+
+        // Next, we will reverse the migration list so we can run them back in the
+        // correct order for resetting this database. This will allow us to get
+        // the database back into its "empty" state ready for the migrations.
+        $migrations = array_reverse($this->repository->getRan());
+
+        if (count($migrations) === 0) {
+            $this->note('<info>Nothing to rollback.</info>');
+
+            return [];
+        }
+
+        return $this->resetMigrations($migrations, $paths, $pretend);
+    }
+
+    /**
+     * Reset the given migrations.
+     *
+     * @param  array  $migrations
+     * @param  array  $paths
+     * @param  bool  $pretend
+     * @return array
+     */
+    protected function resetMigrations(array $migrations, array $paths, $pretend = false)
+    {
+        // Since the getRan method that retrieves the migration name just gives us the
+        // migration name, we will format the names into objects with the name as a
+        // property on the objects so that we can pass it to the rollback method.
+        $migrations = collect($migrations)->map(function ($m) {
+            return (object) ['migration' => $m];
+        })->all();
+
+        return $this->rollbackMigrations(
+            $migrations, $paths, compact('pretend')
+        );
+    }
+
+    /**
+     * Run "down" a migration instance.
+     *
+     * @param  string  $file
+     * @param  object  $migration
+     * @param  bool    $pretend
+     * @return void
+     */
+    protected function runDown($file, $migration, $pretend)
+    {
+        // First we will get the file name of the migration so we can resolve out an
+        // instance of the migration. Once we get an instance we can either run a
+        // pretend execution of the migration or we can run the real migration.
+        $instance = $this->resolve(
+            $name = $this->getMigrationName($file)
+        );
+
+        $this->note("<comment>Rolling back:</comment> {$name}");
+
+        if ($pretend) {
+            return $this->pretendToRun($instance, 'down');
+        }
+
+        $this->runMigration($instance, 'down');
+
+        // Once we have successfully run the migration "down" we will remove it from
+        // the migration repository so it will be considered to have not been run
+        // by the application then will be able to fire by any later operation.
+        $this->repository->delete($migration);
+
+        $this->note("<info>Rolled back:</info>  {$name}");
+    }
+
+    /**
+     * Run a migration inside a transaction if the database supports it.
+     *
+     * @param  object  $migration
+     * @param  string  $method
+     * @return void
+     */
+    protected function runMigration($migration, $method)
+    {
+        $connection = $this->resolveConnection(
+            $migration->getConnection()
+        );
+
+        $callback = function () use ($migration, $method) {
+            if (method_exists($migration, $method)) {
+                $migration->{$method}();
+            }
+        };
+
+        $this->getSchemaGrammar($connection)->supportsSchemaTransactions()
+        && $migration->withinTransaction
+            ? $connection->transaction($callback)
+            : $callback();
+    }
+
+    /**
+     * Pretend to run the migrations.
+     *
+     * @param  object  $migration
+     * @param  string  $method
+     * @return void
+     */
+    protected function pretendToRun($migration, $method)
+    {
+        foreach ($this->getQueries($migration, $method) as $query) {
+            $name = get_class($migration);
+
+            $this->note("<info>{$name}:</info> {$query['query']}");
+        }
+    }
+
+    /**
+     * Get all of the queries that would be run for a migration.
+     *
+     * @param  object  $migration
+     * @param  string  $method
+     * @return array
+     */
+    protected function getQueries($migration, $method)
+    {
+        // Now that we have the connections we can resolve it and pretend to run the
+        // queries against the database returning the array of raw SQL statements
+        // that would get fired against the database system for this migration.
+        $db = $this->resolveConnection(
+            $migration->getConnection()
+        );
+
+        return $db->pretend(function () use ($migration, $method) {
+            if (method_exists($migration, $method)) {
+                $migration->{$method}();
+            }
+        });
+    }
+
+    /**
+     * Resolve a migration instance from a file.
+     *
+     * @param  string  $file
+     * @return object
+     */
+    public function resolve($file)
+    {
+        $class = Str::studly(implode('_', array_slice(explode('_', $file), 4)));
+
+        return new $class;
+    }
+
+    /**
+     * Get all of the migration files in a given path.
+     *
+     * @param  string|array  $paths
+     * @return array
+     */
+    public function getMigrationFiles($paths)
+    {
+        return Collection::make($paths)->flatMap(function ($path) {
+            return Str::endsWith($path, '.php') ? [$path] : $this->files->glob($path.'/*_*.php');
+        })->filter()->sortBy(function ($file) {
+            return $this->getMigrationName($file);
+        })->values()->keyBy(function ($file) {
+            return $this->getMigrationName($file);
+        })->all();
+    }
+
+    /**
+     * Require in all the migration files in a given path.
+     *
+     * @param  array   $files
+     * @return void
+     */
+    public function requireFiles(array $files)
+    {
+        foreach ($files as $file) {
+            $this->files->requireOnce($file);
+        }
+    }
+
+    /**
+     * Get the name of the migration.
+     *
+     * @param  string  $path
+     * @return string
+     */
+    public function getMigrationName($path)
+    {
+        return str_replace('.php', '', basename($path));
+    }
+
+    /**
+     * Register a custom migration path.
+     *
+     * @param  string  $path
+     * @return void
+     */
+    public function path($path)
+    {
+        $this->paths = array_unique(array_merge($this->paths, [$path]));
+    }
+
+    /**
+     * Get all of the custom migration paths.
+     *
+     * @return array
+     */
+    public function paths()
+    {
+        return $this->paths;
+    }
+
+    /**
+     * Get the default connection name.
+     *
+     * @return string
+     */
+    public function getConnection()
+    {
+        return $this->connection;
+    }
+
+    /**
+     * Set the default connection name.
+     *
+     * @param  string  $name
+     * @return void
+     */
+    public function setConnection($name)
+    {
+        if (! is_null($name)) {
+            $this->resolver->setDefaultConnection($name);
+        }
+
+        $this->repository->setSource($name);
+
+        $this->connection = $name;
+    }
+
+    /**
+     * Resolve the database connection instance.
+     *
+     * @param  string  $connection
+     * @return \Illuminate\Database\Connection
+     */
+    public function resolveConnection($connection)
+    {
+        return $this->resolver->connection($connection ?: $this->connection);
+    }
+
+    /**
+     * Get the schema grammar out of a migration connection.
+     *
+     * @param  \Illuminate\Database\Connection  $connection
+     * @return \Illuminate\Database\Schema\Grammars\Grammar
+     */
+    protected function getSchemaGrammar($connection)
+    {
+        if (is_null($grammar = $connection->getSchemaGrammar())) {
+            $connection->useDefaultSchemaGrammar();
+
+            $grammar = $connection->getSchemaGrammar();
+        }
+
+        return $grammar;
+    }
+
+    /**
+     * Get the migration repository instance.
+     *
+     * @return \Colopl\Spanner\Migrations\MigrationRepositoryInterface
+     */
+    public function getRepository()
+    {
+        return $this->repository;
+    }
+
+    /**
+     * Determine if the migration repository exists.
+     *
+     * @return bool
+     */
+    public function repositoryExists()
+    {
+        return $this->repository->repositoryExists();
+    }
+
+    /**
+     * Get the file system instance.
+     *
+     * @return \Illuminate\Filesystem\Filesystem
+     */
+    public function getFilesystem()
+    {
+        return $this->files;
+    }
+
+    /**
+     * Set the output implementation that should be used by the console.
+     *
+     * @param  \Illuminate\Console\OutputStyle  $output
+     * @return $this
+     */
+    public function setOutput(OutputStyle $output)
+    {
+        $this->output = $output;
+
+        return $this;
+    }
+
+    /**
+     * Write a note to the conosle's output.
+     *
+     * @param  string  $message
+     * @return void
+     */
+    protected function note($message)
+    {
+        if ($this->output) {
+            $this->output->writeln($message);
+        }
+    }
+}

--- a/src/Colopl/Spanner/Schema/Grammar.php
+++ b/src/Colopl/Spanner/Schema/Grammar.php
@@ -516,7 +516,7 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
      */
     protected function typeText(Fluent $column)
     {
-        return 'string';
+        return 'string(2621440)';
     }
 
     /**
@@ -527,7 +527,7 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
      */
     protected function typeMediumText(Fluent $column)
     {
-        return 'string';
+        return 'string(2621440)';
     }
 
     /**
@@ -538,7 +538,7 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
      */
     protected function typeLongText(Fluent $column)
     {
-        return 'string';
+        return 'string(2621440)';
     }
 
     /**

--- a/src/Colopl/Spanner/Schema/Grammar.php
+++ b/src/Colopl/Spanner/Schema/Grammar.php
@@ -17,6 +17,7 @@
 
 namespace Colopl\Spanner\Schema;
 
+use RuntimeException;
 use Illuminate\Database\Connection;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Fluent;
@@ -276,6 +277,17 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
     }
 
     /**
+     * Create the column definition for a char type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeChar(Fluent $column)
+    {
+        return "string({$column->length})";
+    }
+
+    /**
      * Create the column definition for a binary type.
      *
      * @param  Fluent  $column
@@ -298,6 +310,17 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
     }
 
     /**
+     * Create the column definition for a medium integer type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeMediumInteger(Fluent $column)
+    {
+        return 'int64';
+    }
+
+    /**
      * Create the column definition for an integer type.
      *
      * @param  Fluent  $column
@@ -309,12 +332,56 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
     }
 
     /**
+     * Create the column definition for a tiny integer type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeTinyInteger(Fluent $column)
+    {
+        return 'int64';
+    }
+
+    /**
+     * Create the column definition for a small integer type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeSmallInteger(Fluent $column)
+    {
+        return 'int64';
+    }
+
+    /**
      * Create the column definition for a float type.
      *
      * @param  Fluent  $column
      * @return string
      */
     protected function typeFloat(Fluent $column)
+    {
+        return 'float64';
+    }
+
+    /**
+     * Create the column definition for a double type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeDouble(Fluent $column)
+    {
+        return 'float64';
+    }
+
+    /**
+     * Create the column definition for a decimal type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeDecimal(Fluent $column)
     {
         return 'float64';
     }
@@ -342,6 +409,39 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
     }
 
     /**
+     * Create the column definition for a date-time (with timezone) type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeDateTimeTz(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a time type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeTime(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a time (with timezone) type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeTimeTz(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
      * Create the column definition for a timestamp type.
      *
      * @param  Fluent  $column
@@ -350,6 +450,28 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
     protected function typeTimestamp(Fluent $column)
     {
         return 'timestamp';
+    }
+
+    /**
+     * Create the column definition for a timestamp (with  timezone) type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeTimestampTz(Fluent $column)
+    {
+        return 'timestamp';
+    }
+
+    /**
+     * Create the column definition for a year type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeYear(Fluent $column)
+    {
+        return 'int64';
     }
 
     /**
@@ -384,6 +506,195 @@ class Grammar extends \Illuminate\Database\Schema\Grammars\Grammar
     protected function typeBoolean(Fluent $column)
     {
         return 'bool';
+    }
+
+    /**
+     * Create the column definition for a text type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeText(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a medium text type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeMediumText(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a long text type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeLongText(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for an enumeration type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeEnum(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a json type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeJson(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a jsonb type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeJsonb(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for an ip address type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeIpAddress(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a mac address type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeMacAddress(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a geometry type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeGeometry(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a point type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typePoint(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a line string type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeLineString(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a polygon type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typePolygon(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a geometry collection type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeGeometryCollection(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a multi point type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeMultiPoint(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a multi line string type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeMultiLineString(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a multi polygon type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     */
+    protected function typeMultiPolygon(Fluent $column)
+    {
+        return 'string';
+    }
+
+    /**
+     * Create the column definition for a computed type.
+     *
+     * @param  Fluent  $column
+     * @return string
+     *
+     * @throws \RuntimeException
+     */
+    protected function typeComputed(Fluent $column)
+    {
+        throw new RuntimeException('This database driver requires a type, see the virtualAs / storedAs modifiers.');
     }
 
     /**

--- a/src/Colopl/Spanner/SpannerServiceProvider.php
+++ b/src/Colopl/Spanner/SpannerServiceProvider.php
@@ -17,6 +17,12 @@
 
 namespace Colopl\Spanner;
 
+use Colopl\Spanner\Console\InstallCommand;
+use Colopl\Spanner\Console\MigrateCommand;
+use Colopl\Spanner\Console\ResetCommand;
+use Colopl\Spanner\Console\RollbackCommand;
+use Colopl\Spanner\Migrations\DatabaseMigrationRepository;
+use Colopl\Spanner\Migrations\Migrator;
 use Exception;
 use Google\Cloud\Spanner\Session\CacheSessionPool;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
@@ -27,6 +33,7 @@ use Psr\Cache\CacheItemPoolInterface;
 
 class SpannerServiceProvider extends ServiceProvider
 {
+
     /**
      * @return void
      */
@@ -37,6 +44,11 @@ class SpannerServiceProvider extends ServiceProvider
                 return $this->createSpannerConnection($this->parseConfig($config, $name));
             });
         });
+
+        $this->registerRepository();
+        $this->registerMigrator();
+        $this->registerCommands();
+
     }
 
     /**
@@ -80,6 +92,121 @@ class SpannerServiceProvider extends ServiceProvider
     {
         $cachePath = storage_path(implode(DIRECTORY_SEPARATOR, ['framework', 'cache', 'spanner']));
         return new FileCacheAdapter('auth', $cachePath);
+    }
+
+    /**
+     * Register the migration repository service.
+     *
+     * @return void
+     */
+    protected function registerRepository()
+    {
+        $this->app->singleton('spanner.migration.repository', function ($app) {
+            $table = $app['config']['database.migrations'];
+            return new DatabaseMigrationRepository($app['db'], $table);
+        });
+    }
+
+
+    /**
+     * Register the migrator service.
+     *
+     * @return void
+     */
+    protected function registerMigrator()
+    {
+        // The migrator is responsible for actually running and rollback the migration
+        // files in the application. We'll pass in our database connection resolver
+        // so the migrator can resolve any of these connections when it needs to.
+        $this->app->singleton('spanner.migrator', function ($app) {
+            $repository = $app['spanner.migration.repository'];
+            return new Migrator($repository, $app['db'], $app['files']);
+        });
+    }
+
+    /**
+     * Register all of the Commands
+     *
+     * @return void
+     */
+    protected function registerCommands()
+    {
+        $this->registerMigrateCommand();
+        $this->registerMigrateInstallCommand();
+        $this->registerMigrateResetCommand();
+        $this->registerMigrateRollbackCommand();
+        $this->commands([
+            'spanner.command.migrate',
+            'spanner.command.migrate.install',
+            'spanner.command.migrate.reset',
+            'spanner.command.migrate.rollback',
+        ]);
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateCommand()
+    {
+        $this->app->singleton('spanner.command.migrate', function ($app) {
+            return new MigrateCommand($app['spanner.migrator']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateInstallCommand()
+    {
+        $this->app->singleton('spanner.command.migrate.install', function ($app) {
+            return new InstallCommand($app['spanner.migration.repository']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateResetCommand()
+    {
+        $this->app->singleton('spanner.command.migrate.reset', function ($app) {
+            return new ResetCommand($app['spanner.migrator']);
+        });
+    }
+
+    /**
+     * Register the command.
+     *
+     * @return void
+     */
+    protected function registerMigrateRollbackCommand()
+    {
+        $this->app->singleton('spanner.command.migrate.rollback', function ($app) {
+            return new RollbackCommand($app['spanner.migrator']);
+        });
+    }
+
+    /**
+     * Get the services provided by the provider.
+     *
+     * @return array
+     */
+    public function provides()
+    {
+        return [
+            'db.spanner',
+            'spanner.migrator',
+            'spanner.migration.repository',
+            'spanner.command.migrate',
+            'spanner.command.migrate.install',
+            'spanner.command.migrate.reset',
+            'spanner.command.migrate.rollback',
+        ];
     }
 
 }

--- a/tests/Colopl/Spanner/Console/DatabaseMigrationInstallCommandTest.php
+++ b/tests/Colopl/Spanner/Console/DatabaseMigrationInstallCommandTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Colopl\Spanner\Tests\Console;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Colopl\Spanner\Console\InstallCommand;
+use Colopl\Spanner\Migrations\MigrationRepositoryInterface;
+
+class DatabaseMigrationInstallCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testFireCallsRepositoryToInstall()
+    {
+        $command = new InstallCommand($repo = m::mock(MigrationRepositoryInterface::class));
+        $command->setLaravel(new Application);
+        $repo->shouldReceive('setSource')->once()->with('foo');
+        $repo->shouldReceive('createRepository')->once();
+
+        $this->runCommand($command, ['--database' => 'foo']);
+    }
+
+    protected function runCommand($command, $options = [])
+    {
+        return $command->run(new ArrayInput($options), new NullOutput);
+    }
+}

--- a/tests/Colopl/Spanner/Console/DatabaseMigrationMigrateCommandTest.php
+++ b/tests/Colopl/Spanner/Console/DatabaseMigrationMigrateCommandTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace Colopl\Spanner\Tests\Console;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Colopl\Spanner\Migrations\Migrator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Colopl\Spanner\Console\MigrateCommand;
+
+class DatabaseMigrationMigrateCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testBasicMigrationsCallMigratorWithProperArguments()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('getNotes')->andReturn([]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command);
+    }
+
+    public function testMigrationRepositoryCreatedWhenNecessary()
+    {
+        $params = [$migrator = m::mock(Migrator::class)];
+        $command = $this->getMockBuilder(MigrateCommand::class)->setMethods(['call'])->setConstructorArgs($params)->getMock();
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(false);
+        $command->expects($this->once())->method('call')->with($this->equalTo('migrate:install'), $this->equalTo([]));
+
+        $this->runCommand($command);
+    }
+
+    public function testTheCommandMayBePretended()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => false]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--pretend' => true]);
+    }
+
+    public function testTheDatabaseMayBeSet()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => false]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--database' => 'foo']);
+    }
+
+    public function testStepMayBeSet()
+    {
+        $command = new MigrateCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseMigrationStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('run')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => true]);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+
+        $this->runCommand($command, ['--step' => true]);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class ApplicationDatabaseMigrationStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment()
+    {
+        return 'development';
+    }
+}

--- a/tests/Colopl/Spanner/Console/DatabaseMigrationResetCommandTest.php
+++ b/tests/Colopl/Spanner/Console/DatabaseMigrationResetCommandTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Colopl\Spanner\Tests\Console;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Colopl\Spanner\Migrations\Migrator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Colopl\Spanner\Console\ResetCommand;
+
+class DatabaseMigrationResetCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testResetCommandCallsMigratorWithProperArguments()
+    {
+        $command = new ResetCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], false);
+
+        $this->runCommand($command);
+    }
+
+    public function testResetCommandCanBePretended()
+    {
+        $command = new ResetCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseResetStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('repositoryExists')->once()->andReturn(true);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('reset')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class ApplicationDatabaseResetStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment()
+    {
+        return 'development';
+    }
+}

--- a/tests/Colopl/Spanner/Console/DatabaseMigrationRollbackCommandTest.php
+++ b/tests/Colopl/Spanner/Console/DatabaseMigrationRollbackCommandTest.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace Colopl\Spanner\Tests\Console;
+
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Foundation\Application;
+use Colopl\Spanner\Migrations\Migrator;
+use Symfony\Component\Console\Input\ArrayInput;
+use Symfony\Component\Console\Output\NullOutput;
+use Colopl\Spanner\Console\RollbackCommand;
+
+class DatabaseMigrationRollbackCommandTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testRollbackCommandCallsMigratorWithProperArguments()
+    {
+        $command = new RollbackCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 0]);
+
+        $this->runCommand($command);
+    }
+
+    public function testRollbackCommandCallsMigratorWithStepOption()
+    {
+        $command = new RollbackCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with(null);
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => false, 'step' => 2]);
+
+        $this->runCommand($command, ['--step' => 2]);
+    }
+
+    public function testRollbackCommandCanBePretended()
+    {
+        $command = new RollbackCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], true);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo']);
+    }
+
+    public function testRollbackCommandCanBePretendedWithStepOption()
+    {
+        $command = new RollbackCommand($migrator = m::mock(Migrator::class));
+        $app = new ApplicationDatabaseRollbackStub(['path.database' => __DIR__]);
+        $app->useDatabasePath(__DIR__);
+        $command->setLaravel($app);
+        $migrator->shouldReceive('paths')->once()->andReturn([]);
+        $migrator->shouldReceive('setConnection')->once()->with('foo');
+        $migrator->shouldReceive('setOutput')->once()->andReturn($migrator);
+        $migrator->shouldReceive('rollback')->once()->with([__DIR__.DIRECTORY_SEPARATOR.'migrations'], ['pretend' => true, 'step' => 2]);
+
+        $this->runCommand($command, ['--pretend' => true, '--database' => 'foo', '--step' => 2]);
+    }
+
+    protected function runCommand($command, $input = [])
+    {
+        return $command->run(new ArrayInput($input), new NullOutput);
+    }
+}
+
+class ApplicationDatabaseRollbackStub extends Application
+{
+    public function __construct(array $data = [])
+    {
+        foreach ($data as $abstract => $instance) {
+            $this->instance($abstract, $instance);
+        }
+    }
+
+    public function environment()
+    {
+        return 'development';
+    }
+}

--- a/tests/Colopl/Spanner/Migrations/DatabaseMigrationRepositoryTest.php
+++ b/tests/Colopl/Spanner/Migrations/DatabaseMigrationRepositoryTest.php
@@ -1,0 +1,122 @@
+<?php
+
+namespace Colopl\Spanner\Tests\Migrations;
+
+use Closure;
+use Ramsey\Uuid\Uuid;
+use stdClass;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Support\Collection;
+use Illuminate\Database\Connection;
+use Illuminate\Database\ConnectionResolverInterface;
+use Colopl\Spanner\Migrations\DatabaseMigrationRepository;
+
+class DatabaseMigrationRepositoryTest extends TestCase
+{
+    public function tearDown()
+    {
+        m::close();
+    }
+
+    public function testGetRanMigrationsListMigrationsByPackage()
+    {
+        $repo = $this->getRepository();
+        $query = m::mock(stdClass::class);
+        $connectionMock = m::mock(Connection::class);
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('batch', 'asc')->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('migration', 'asc')->andReturn($query);
+        $query->shouldReceive('pluck')->once()->with('migration')->andReturn(new Collection(['bar']));
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
+
+        $this->assertEquals(['bar'], $repo->getRan());
+    }
+
+    public function testGetLastMigrationsGetsAllMigrationsWithTheLatestBatchNumber()
+    {
+        $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+            $resolver = m::mock(ConnectionResolverInterface::class), 'migrations',
+        ])->getMock();
+        $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
+        $query = m::mock(stdClass::class);
+        $connectionMock = m::mock(Connection::class);
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('batch', 1)->andReturn($query);
+        $query->shouldReceive('orderBy')->once()->with('migration', 'desc')->andReturn($query);
+        $query->shouldReceive('get')->once()->andReturn(new Collection(['foo']));
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
+
+        $this->assertEquals(['foo'], $repo->getLast());
+    }
+
+    public function testLogMethodInsertsRecordIntoMigrationTable()
+    {
+        $repo = $this->getRepository();
+        $query = m::mock(stdClass::class);
+        $connectionMock = m::mock(Connection::class);
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('insert')->once()->with(['id' => Uuid::uuid4()->toString(),'migration' => 'bar', 'batch' => 1]);
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
+
+        $repo->log('bar', 1);
+    }
+
+    public function testDeleteMethodRemovesAMigrationFromTheTable()
+    {
+        $repo = $this->getRepository();
+        $query = m::mock(stdClass::class);
+        $connectionMock = m::mock(Connection::class);
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('where')->once()->with('migration', 'foo')->andReturn($query);
+        $query->shouldReceive('delete')->once();
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
+        $migration = (object) ['migration' => 'foo'];
+
+        $repo->delete($migration);
+    }
+
+    public function testGetNextBatchNumberReturnsLastBatchNumberPlusOne()
+    {
+        $repo = $this->getMockBuilder(DatabaseMigrationRepository::class)->setMethods(['getLastBatchNumber'])->setConstructorArgs([
+            m::mock(ConnectionResolverInterface::class), 'migrations',
+        ])->getMock();
+        $repo->expects($this->once())->method('getLastBatchNumber')->will($this->returnValue(1));
+
+        $this->assertEquals(2, $repo->getNextBatchNumber());
+    }
+
+    public function testGetLastBatchNumberReturnsMaxBatch()
+    {
+        $repo = $this->getRepository();
+        $query = m::mock(stdClass::class);
+        $connectionMock = m::mock(Connection::class);
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('table')->once()->with('migrations')->andReturn($query);
+        $query->shouldReceive('max')->once()->andReturn(1);
+        $query->shouldReceive('useWritePdo')->once()->andReturn($query);
+
+        $this->assertEquals(1, $repo->getLastBatchNumber());
+    }
+
+    public function testCreateRepositoryCreatesProperDatabaseTable()
+    {
+        $repo = $this->getRepository();
+        $schema = m::mock(stdClass::class);
+        $connectionMock = m::mock(Connection::class);
+        $repo->getConnectionResolver()->shouldReceive('connection')->with(null)->andReturn($connectionMock);
+        $repo->getConnection()->shouldReceive('getSchemaBuilder')->once()->andReturn($schema);
+        $schema->shouldReceive('create')->once()->with('migrations', m::type(Closure::class));
+
+        $repo->createRepository();
+    }
+
+    protected function getRepository()
+    {
+        return new DatabaseMigrationRepository(m::mock(ConnectionResolverInterface::class), 'migrations');
+    }
+}

--- a/tests/Colopl/Spanner/Migrations/DatabaseMigratorIntegrationTest.php
+++ b/tests/Colopl/Spanner/Migrations/DatabaseMigratorIntegrationTest.php
@@ -1,0 +1,150 @@
+<?php
+
+namespace Colopl\Spanner\Tests\Migrations;
+
+use Mockery as m;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\TestCase;
+use Illuminate\Console\OutputStyle;
+use Illuminate\Container\Container;
+use Illuminate\Filesystem\Filesystem;
+use Illuminate\Support\Facades\Facade;
+use Colopl\Spanner\Migrations\Migrator;
+use Illuminate\Database\Capsule\Manager as DB;
+use Colopl\Spanner\Migrations\DatabaseMigrationRepository;
+
+class DatabaseMigratorIntegrationTest extends TestCase
+{
+    protected $db;
+    protected $migrator;
+
+    /**
+     * Bootstrap Eloquent.
+     *
+     * @return void
+     */
+    public function setUp()
+    {
+        $this->db = $db = new DB;
+
+        $db->addConnection([
+            'driver'    => 'sqlite',
+            'database'  => ':memory:',
+        ]);
+
+        $db->setAsGlobal();
+
+        $container = new Container;
+        $container->instance('db', $db->getDatabaseManager());
+        Facade::setFacadeApplication($container);
+
+        $this->migrator = new Migrator(
+            $repository = new DatabaseMigrationRepository($db->getDatabaseManager(), 'migrations'),
+            $db->getDatabaseManager(),
+            new Filesystem
+        );
+
+        $output = m::mock(OutputStyle::class);
+        $output->shouldReceive('writeln');
+
+        $this->migrator->setOutput($output);
+
+        if (! $repository->repositoryExists()) {
+            $repository->createRepository();
+        }
+    }
+
+    public function tearDown()
+    {
+        Facade::clearResolvedInstances();
+        Facade::setFacadeApplication(null);
+    }
+
+    public function testBasicMigrationOfSingleFolder()
+    {
+        $ran = $this->migrator->run([__DIR__.'/migrations/one']);
+
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+
+        $this->assertTrue(Str::contains($ran[0], 'users'));
+        $this->assertTrue(Str::contains($ran[1], 'password_resets'));
+    }
+
+    public function testMigrationsCanBeRolledBack()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $rolledBack = $this->migrator->rollback([__DIR__.'/migrations/one']);
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+
+        $this->assertTrue(Str::contains($rolledBack[0], 'password_resets'));
+        $this->assertTrue(Str::contains($rolledBack[1], 'users'));
+    }
+
+    public function testMigrationsCanBeReset()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $rolledBack = $this->migrator->reset([__DIR__.'/migrations/one']);
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+
+        $this->assertTrue(Str::contains($rolledBack[0], 'password_resets'));
+        $this->assertTrue(Str::contains($rolledBack[1], 'users'));
+    }
+
+    public function testNoErrorIsThrownWhenNoOutstandingMigrationsExist()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->migrator->run([__DIR__.'/migrations/one']);
+    }
+
+    public function testNoErrorIsThrownWhenNothingToRollback()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->migrator->rollback([__DIR__.'/migrations/one']);
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->migrator->rollback([__DIR__.'/migrations/one']);
+    }
+
+    public function testMigrationsCanRunAcrossMultiplePaths()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db->schema()->hasTable('flights'));
+    }
+
+    public function testMigrationsCanBeRolledBackAcrossMultiplePaths()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db->schema()->hasTable('flights'));
+        $this->migrator->rollback([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db->schema()->hasTable('flights'));
+    }
+
+    public function testMigrationsCanBeResetAcrossMultiplePaths()
+    {
+        $this->migrator->run([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
+        $this->assertTrue($this->db->schema()->hasTable('users'));
+        $this->assertTrue($this->db->schema()->hasTable('password_resets'));
+        $this->assertTrue($this->db->schema()->hasTable('flights'));
+        $this->migrator->reset([__DIR__.'/migrations/one', __DIR__.'/migrations/two']);
+        $this->assertFalse($this->db->schema()->hasTable('users'));
+        $this->assertFalse($this->db->schema()->hasTable('password_resets'));
+        $this->assertFalse($this->db->schema()->hasTable('flights'));
+    }
+}

--- a/tests/Colopl/Spanner/Migrations/migrations/one/2016_01_01_000000_create_users_table.php
+++ b/tests/Colopl/Spanner/Migrations/migrations/one/2016_01_01_000000_create_users_table.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateUsersTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('users', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+            $table->string('email')->unique();
+            $table->string('password');
+            $table->rememberToken();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('users');
+    }
+}

--- a/tests/Colopl/Spanner/Migrations/migrations/one/2016_01_01_100000_create_password_resets_table.php
+++ b/tests/Colopl/Spanner/Migrations/migrations/one/2016_01_01_100000_create_password_resets_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class CreatePasswordResetsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('password_resets', function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->string('email')->index();
+            $table->string('token')->index();
+            $table->timestamp('created_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('password_resets');
+    }
+}

--- a/tests/Colopl/Spanner/Migrations/migrations/two/2016_01_01_200000_create_flights_table.php
+++ b/tests/Colopl/Spanner/Migrations/migrations/two/2016_01_01_200000_create_flights_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Database\Migrations\Migration;
+
+class CreateFlightsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('flights', function ($table) {
+            $table->uuid('id')->primary();
+            $table->string('name');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('flights');
+    }
+}


### PR DESCRIPTION
Work in Progress Migration Support for Feedback!

It's a re-work of the default Laravel migration service and commands to work with Cloud Spanner (Should work with a normal MySQL database as well for local development).

Let me know if you're OK with the approach and i'll get it cleaned up and tested!

**Features**
- More Grammar added to allow easier porting of existing codebases to Cloud Spanner
- Adds `spanner:migrate` commands that use UUIDs

**Outstanding**
- [ ] Tests
- [ ] Research speeding up table creations with DDL