### PR TITLE
feat: handle 'session not found' errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,18 +248,18 @@ or anything that doesn't call Spanner frequently enough (more than once an hour)
 
 The errors can be handled by one of the supported modes:
 
-- **MAINTAIN_SESSION_POOL** - When the 'session not found' error is encountered, the library tries to disconnect,
+- **MAINTAIN_SESSION_POOL** (default) - When the 'session not found' error is encountered, the library tries to disconnect,
 [maintain a session pool](https://github.com/googleapis/google-cloud-php/blob/077810260b58f5de8a3bbdfd999a5e9a48f71a7f/Spanner/src/Session/CacheSessionPool.php#L864)
 (to remove outdated sessions), reconnect, and then try querying again.
 ```php
         'spanner' => [
             'driver' => 'spanner',
         ...
-   	        'sessionNotFoundErrorMode' => 'MAINTAIN_SESSION_POOL',
+            'sessionNotFoundErrorMode' => 'MAINTAIN_SESSION_POOL',
         ]
 ```
 
-- **CLEAR_SESSION_POOL** (default) - The **MAINTAIN_SESSION_POOL** mode is tried first. If the error still happens, then
+- **CLEAR_SESSION_POOL** - The **MAINTAIN_SESSION_POOL** mode is tried first. If the error still happens, then
 the [clearing of the session pool](https://github.com/googleapis/google-cloud-php/blob/077810260b58f5de8a3bbdfd999a5e9a48f71a7f/Spanner/src/Session/CacheSessionPool.php#L465)
 is enforced and the query is tried once again.
 As a consequence of session pool clearing, all processes that share the current session pool will be forced
@@ -268,16 +268,16 @@ to use the new session on the next call. The mode is enabled by default, but you
         'spanner' => [
             'driver' => 'spanner',
         ...
-       	    'sessionNotFoundErrorMode' => 'CLEAR_SESSION_POOL'
+            'sessionNotFoundErrorMode' => 'CLEAR_SESSION_POOL'
         ]
 ```
 
-- none - The QueryException is raised and the client code is free to handle it by itself.:
+- **THROW_EXCEPTION** - The QueryException is raised and the client code is free to handle it by itself.:
 ```php
         'spanner' => [
             'driver' => 'spanner',
         ...
-   	        'sessionNotFoundErrorMode' => false,
+            'sessionNotFoundErrorMode' => 'THROW_EXCEPTION',
         ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ The errors can be handled by one of the supported modes:
 - **MAINTAIN_SESSION_POOL** (default) - When the 'session not found' error is encountered, the library tries to disconnect,
 [maintain a session pool](https://github.com/googleapis/google-cloud-php/blob/077810260b58f5de8a3bbdfd999a5e9a48f71a7f/Spanner/src/Session/CacheSessionPool.php#L864)
 (to remove outdated sessions), reconnect, and then try querying again.
+The mode is enabled by default, but you can enable it explicitly via congifuration:
 ```php
         'spanner' => [
             'driver' => 'spanner',
@@ -263,7 +264,7 @@ The errors can be handled by one of the supported modes:
 the [clearing of the session pool](https://github.com/googleapis/google-cloud-php/blob/077810260b58f5de8a3bbdfd999a5e9a48f71a7f/Spanner/src/Session/CacheSessionPool.php#L465)
 is enforced and the query is tried once again.
 As a consequence of session pool clearing, all processes that share the current session pool will be forced
-to use the new session on the next call. The mode is enabled by default, but you can enable it explicitly via congifuration:
+to use the new session on the next call.
 ```php
         'spanner' => [
             'driver' => 'spanner',

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -16,8 +16,6 @@ parameters:
           path: src/Colopl/Spanner/Connection.php
         - message: '#^Method Colopl\\Spanner\\Connection::getSpannerDatabase\(\) should return Google\\Cloud\\Spanner\\Database but returns Google\\Cloud\\Spanner\\Database\|null.$#'
           path: src/Colopl/Spanner/Connection.php
-        - message: '#^Method Colopl\\Spanner\\Connection::transaction\(\) should return T but returns mixed\.$#'
-          path: src/Colopl/Spanner/Connection.php
         - message: '#^Cannot cast mixed to int\.$#'
           path: src/Colopl/Spanner/Eloquent/Model.php
         - message: '#^Method Colopl\\Spanner\\Query\\Builder::insertGetId\(\) should return int but return statement is missing\.$#'

--- a/src/Colopl/Spanner/Concerns/ManagesSessionPool.php
+++ b/src/Colopl/Spanner/Concerns/ManagesSessionPool.php
@@ -81,7 +81,8 @@ trait ManagesSessionPool
     {
         $databaseName = $this->getSpannerDatabase()->name();
         $response = (new ProtobufSpannerClient())->listSessions($databaseName);
-        return collect($response->iterateAllElements())->map(function (ProtobufSpannerSession $session) {
+        return collect($response->iterateAllElements())->map(function ($session) {
+            assert($session instanceof ProtobufSpannerSession);
             return new Session($session);
         });
     }

--- a/src/Colopl/Spanner/Concerns/ManagesStaleReads.php
+++ b/src/Colopl/Spanner/Concerns/ManagesStaleReads.php
@@ -56,7 +56,7 @@ trait ManagesStaleReads
      */
     public function selectWithTimestampBound($query, $bindings = [], TimestampBoundInterface $timestampBound = null): array
     {
-        return $this->sessionNotFoundWrapper(function () use ($query, $bindings, $timestampBound) {
+        return $this->withSessionNotFoundHandling(function () use ($query, $bindings, $timestampBound) {
             return iterator_to_array($this->cursorWithTimestampBound($query, $bindings, $timestampBound));
         });
     }
@@ -70,7 +70,7 @@ trait ManagesStaleReads
      */
     public function selectOneWithTimestampBound($query, $bindings = [], TimestampBoundInterface $timestampBound = null): ?array
     {
-        $result = $this->sessionNotFoundWrapper(function () use ($query, $bindings, $timestampBound) {
+        $result = $this->withSessionNotFoundHandling(function () use ($query, $bindings, $timestampBound) {
             return $this->cursorWithTimestampBound($query, $bindings, $timestampBound)->current();
         });
         assert(is_null($result) || is_array($result));

--- a/src/Colopl/Spanner/Concerns/ManagesStaleReads.php
+++ b/src/Colopl/Spanner/Concerns/ManagesStaleReads.php
@@ -56,7 +56,9 @@ trait ManagesStaleReads
      */
     public function selectWithTimestampBound($query, $bindings = [], TimestampBoundInterface $timestampBound = null): array
     {
-        return iterator_to_array($this->cursorWithTimestampBound($query, $bindings, $timestampBound));
+        return $this->sessionNotFoundWrapper(function () use ($query, $bindings, $timestampBound) {
+            return iterator_to_array($this->cursorWithTimestampBound($query, $bindings, $timestampBound));
+        });
     }
 
     /**
@@ -68,7 +70,11 @@ trait ManagesStaleReads
      */
     public function selectOneWithTimestampBound($query, $bindings = [], TimestampBoundInterface $timestampBound = null): ?array
     {
-        return $this->cursorWithTimestampBound($query, $bindings, $timestampBound)->current();
+        $result = $this->sessionNotFoundWrapper(function () use ($query, $bindings, $timestampBound) {
+            return $this->cursorWithTimestampBound($query, $bindings, $timestampBound)->current();
+        });
+        assert(is_null($result) || is_array($result));
+        return $result;
     }
 }
 

--- a/src/Colopl/Spanner/Concerns/ManagesTransactions.php
+++ b/src/Colopl/Spanner/Concerns/ManagesTransactions.php
@@ -47,7 +47,7 @@ trait ManagesTransactions
      */
     public function transaction(Closure $callback, $attempts = Database::MAX_RETRIES)
     {
-        return $this->sessionNotFoundWrapper(function () use ($callback, $attempts) {
+        return $this->withSessionNotFoundHandling(function () use ($callback, $attempts) {
             // Since Cloud Spanner does not support nested transactions,
             // we use Laravel's transaction management for nested transactions only.
             if ($this->transactions > 0) {

--- a/src/Colopl/Spanner/Concerns/ManagesTransactions.php
+++ b/src/Colopl/Spanner/Concerns/ManagesTransactions.php
@@ -67,7 +67,7 @@ trait ManagesTransactions
                     // so quietly ignore 'session not found' error
                     // and then abort current transaction and rerun everything again
                     $savedIgnoreError = $this->ignoreSessionNotFoundErrorOnRollback;
-                    $this->ignoreSessionNotFoundErrorOnRollback = !empty($this->getSessionNotFoundMode())
+                    $this->ignoreSessionNotFoundErrorOnRollback = $this->getSessionNotFoundMode() != self::THROW_EXCEPTION
                         && $this->causedBySessionNotFound($e);
 
                     try {
@@ -79,7 +79,7 @@ trait ManagesTransactions
                 } catch (AbortedException $e) {
                     // if aborted was caused by session not found, then ignore errors on rollback
                     $savedIgnoreError = $this->ignoreSessionNotFoundErrorOnRollback;
-                    $this->ignoreSessionNotFoundErrorOnRollback = !empty($this->getSessionNotFoundMode())
+                    $this->ignoreSessionNotFoundErrorOnRollback = $this->getSessionNotFoundMode() != self::THROW_EXCEPTION
                         && $e->hasServiceException()
                         && $this->causedBySessionNotFound($e->getServiceException());
 

--- a/src/Colopl/Spanner/Connection.php
+++ b/src/Colopl/Spanner/Connection.php
@@ -30,6 +30,7 @@ use Exception;
 use Generator;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Core\Exception\GoogleException;
+use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Session\SessionPoolInterface;
 use Google\Cloud\Spanner\SpannerClient;
@@ -37,6 +38,7 @@ use Google\Cloud\Spanner\Transaction;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Database\QueryException;
+use InvalidArgumentException;
 use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 use Throwable;
@@ -81,6 +83,21 @@ class Connection extends BaseConnection
      * @var SessionPoolInterface|null
      */
     protected $sessionPool;
+
+    /**
+     * Try to maintain session pool on 'session not found' error
+     */
+    public const MAINTAIN_SESSION_POOL = 'MAINTAIN_SESSION_POOL';
+
+    /**
+     * Try to maintain and then clear session pool on 'session not found' error
+     */
+    public const CLEAR_SESSION_POOL = 'CLEAR_SESSION_POOL';
+
+    /**
+     * Used to detect specific exception
+     */
+    public const SESSION_NOT_FOUND_CONDITION = 'Session does not exist';
 
     /**
      * @param string $instanceId instance ID
@@ -425,7 +442,9 @@ class Connection extends BaseConnection
         [$query, $bindings] = $this->parameterizer->parameterizeQuery($query, $bindings);
 
         try {
-            $result = $callback($query, $bindings);
+            $result = $this->sessionNotFoundWrapper(function () use ($query, $bindings, $callback) {
+                return $callback($query, $bindings);
+            });
         }
 
         // AbortedExceptions are expected to be thrown upstream by the Google Client Library upstream,
@@ -443,4 +462,83 @@ class Connection extends BaseConnection
 
         return $result;
     }
+
+    /**
+     * Returns current mode
+     *
+     * @return string
+     */
+    protected function getSessionNotFoundMode()
+    {
+        return $this->config['sessionNotFoundErrorMode'] ?? self::CLEAR_SESSION_POOL;
+    }
+
+    /**
+     * Handle "session not found" errors
+     *
+     * @template T
+     * @param  Closure(): T $callback
+     * @return T
+     * @throws InvalidArgumentException|NotFoundException|AbortedException
+     */
+    protected function sessionNotFoundWrapper(Closure $callback)
+    {
+        $handlerMode = $this->getSessionNotFoundMode();
+        if (empty($handlerMode) || $this->sessionPool === null) {
+            // skip handlers
+            return $callback();
+        }
+
+        if (!in_array($handlerMode, [
+                self::MAINTAIN_SESSION_POOL,
+                self::CLEAR_SESSION_POOL,
+            ])
+        ) {
+            throw new InvalidArgumentException("Unsupported sessionNotFoundErrorMode [{$handlerMode}].");
+        }
+        try {
+            return $callback();
+        } catch (NotFoundException $e) {
+            // ensure if this really error with session
+            if ($this->causedBySessionNotFound($e)) {
+                if ($this->inTransaction()) {
+                    // if we inside transaction then throw abort exception
+                    throw new AbortedException(self::SESSION_NOT_FOUND_CONDITION, $e->getCode(), $e);
+                }
+                $this->disconnect();
+                // clear expired sessions, manually deleted sessions still raise error
+                $this->maintainSessionPool();
+                $this->reconnect();
+                try {
+                    return $callback();
+                } catch (NotFoundException $e) {
+                    if ($handlerMode == self::CLEAR_SESSION_POOL && $this->causedBySessionNotFound($e)) {
+                        $this->disconnect();
+                        // forcefully clearing sessions, might affect parallel processes
+                        // also cleared sessions are still accounted toward spanner limit - 10k sessions per node
+                        $this->clearSessionPool();
+                        $this->reconnect();
+                        return $callback();
+                    } else {
+                        throw $e;
+                    }
+                }
+            } else {
+                throw $e;
+            }
+        }
+    }
+
+    /**
+     * Check if this is "session not found" error
+     *
+     * @param  Throwable  $e
+     * @return boolean
+     */
+    public function causedBySessionNotFound(Throwable $e): bool
+    {
+        return ($e instanceof NotFoundException)
+            && strpos($e->getMessage(), self::SESSION_NOT_FOUND_CONDITION) !== false;
+    }
+
 }

--- a/src/Colopl/Spanner/Connection.php
+++ b/src/Colopl/Spanner/Connection.php
@@ -447,7 +447,7 @@ class Connection extends BaseConnection
         [$query, $bindings] = $this->parameterizer->parameterizeQuery($query, $bindings);
 
         try {
-            $result = $this->sessionNotFoundWrapper(function () use ($query, $bindings, $callback) {
+            $result = $this->withSessionNotFoundHandling(function () use ($query, $bindings, $callback) {
                 return $callback($query, $bindings);
             });
         }
@@ -486,7 +486,7 @@ class Connection extends BaseConnection
      * @return T
      * @throws InvalidArgumentException|NotFoundException|AbortedException
      */
-    protected function sessionNotFoundWrapper(Closure $callback)
+    protected function withSessionNotFoundHandling(Closure $callback): mixed
     {
         $handlerMode = $this->getSessionNotFoundMode();
         if (!in_array($handlerMode, [

--- a/src/Colopl/Spanner/Connection.php
+++ b/src/Colopl/Spanner/Connection.php
@@ -519,7 +519,7 @@ class Connection extends BaseConnection
                 try {
                     return $callback();
                 } catch (NotFoundException $e) {
-                    if ($handlerMode == self::CLEAR_SESSION_POOL && $this->causedBySessionNotFound($e)) {
+                    if ($handlerMode === self::CLEAR_SESSION_POOL && $this->causedBySessionNotFound($e)) {
                         $this->disconnect();
                         // forcefully clearing sessions, might affect parallel processes
                         // also cleared sessions are still accounted toward spanner limit - 10k sessions per node

--- a/tests/Colopl/Spanner/SessionNotFoundTest.php
+++ b/tests/Colopl/Spanner/SessionNotFoundTest.php
@@ -80,6 +80,26 @@ class SessionNotFoundTest extends TestCase
         $this->assertEquals(2, $passes, 'Transaction should be called twice');
     }
 
+    public function testInTransactionRollbackSessionNotFoundHandledError()
+    {
+        $conn = $this->getDefaultConnection();
+
+        $passes = 0;
+
+        $conn->transaction(function () use ($conn, &$passes) {
+
+            $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
+
+            if ($passes == 0) {
+                $this->deleteSession($conn);
+            }
+            $passes++;
+            // explicit rollback should force rerunning of code
+            $conn->rollback();
+        });
+        $this->assertEquals(2, $passes, 'Transaction should be called twice');
+    }
+
     public function testNestedTransactionsSessionNotFoundHandledError()
     {
         $conn = $this->getDefaultConnection();

--- a/tests/Colopl/Spanner/SessionNotFoundTest.php
+++ b/tests/Colopl/Spanner/SessionNotFoundTest.php
@@ -25,6 +25,8 @@ use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class SessionNotFoundTest extends TestCase
 {
+    protected const TEST_DB_REQUIRED = true;
+
     private function deleteSession(Connection $connection)
     {
         // delete session on spanner side
@@ -42,6 +44,9 @@ class SessionNotFoundTest extends TestCase
         $cacheSessionPool = new CacheSessionPool($cacheItemPool);
         $conn = new Connection($config['instance'], $config['database'], '', $config, null, $cacheSessionPool);
 
+        if (static::TEST_DB_REQUIRED) {
+            $this->setUpDatabaseOnce($conn);
+        }
         return $conn;
     }
 

--- a/tests/Colopl/Spanner/SessionNotFoundTest.php
+++ b/tests/Colopl/Spanner/SessionNotFoundTest.php
@@ -166,8 +166,8 @@ class SessionNotFoundTest extends TestCase
 
         $this->expectException(QueryException::class);
 
-        // that string is used in sessionNotFoundWrapper() to catch session not found error,
-        // if google changes it then string should be changed in sessionNotFoundWrapper() as well
+        // the string is used in sessionNotFoundWrapper() to catch 'session not found' error,
+        // if google changes it then string should be changed in Connection::SESSION_NOT_FOUND_CONDITION
         $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
 
         $conn->selectOne('SELECT 1');
@@ -185,8 +185,8 @@ class SessionNotFoundTest extends TestCase
 
         $this->expectException(NotFoundException::class);
 
-        // that string is used in sessionNotFoundWrapper() to catch session not found error,
-        // if google changes it then string should be changed in sessionNotFoundWrapper() as well
+        // the string is used in sessionNotFoundWrapper() to catch 'session not found' error,
+        // if google changes it then string should be changed in Connection::SESSION_NOT_FOUND_CONDITION
         $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
 
         iterator_to_array($cursor);
@@ -199,8 +199,8 @@ class SessionNotFoundTest extends TestCase
 
         $this->expectException(NotFoundException::class);
 
-        // that string is used in sessionNotFoundWrapper() to catch session not found error,
-        // if google changes it then string should be changed in sessionNotFoundWrapper() as well
+        // the string is used in sessionNotFoundWrapper() to catch 'session not found' error,
+        // if google changes it then string should be changed in Connection::SESSION_NOT_FOUND_CONDITION
         $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
 
         $passes = 0;

--- a/tests/Colopl/Spanner/SessionNotFoundTest.php
+++ b/tests/Colopl/Spanner/SessionNotFoundTest.php
@@ -64,7 +64,7 @@ class SessionNotFoundTest extends TestCase
 
         $conn->transaction(function () use ($conn, &$passes) {
 
-            if ($passes == 0) {
+            if ($passes === 0) {
                 $this->deleteSession($conn);
                 $passes++;
             }
@@ -86,7 +86,7 @@ class SessionNotFoundTest extends TestCase
 
             $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
 
-            if ($passes == 0) {
+            if ($passes === 0) {
                 $this->deleteSession($conn);
             }
             $passes++;
@@ -104,7 +104,7 @@ class SessionNotFoundTest extends TestCase
 
             $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
 
-            if ($passes == 0) {
+            if ($passes === 0) {
                 $this->deleteSession($conn);
             }
             $passes++;
@@ -124,7 +124,7 @@ class SessionNotFoundTest extends TestCase
             $conn->transaction(function () use ($conn, &$passes) {
                 $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
 
-                if ($passes == 0) {
+                if ($passes === 0) {
                     $this->deleteSession($conn);
                 }
                 $passes++;
@@ -142,7 +142,7 @@ class SessionNotFoundTest extends TestCase
         $conn->transaction(function () use ($conn, &$passes) {
             $cursor = $conn->cursor('SELECT 12345');
 
-            if ($passes == 0) {
+            if ($passes === 0) {
                 $this->deleteSession($conn);
                 $passes++;
             }
@@ -207,7 +207,7 @@ class SessionNotFoundTest extends TestCase
 
         $conn->transaction(function () use ($conn, &$passes) {
 
-            if ($passes == 0) {
+            if ($passes === 0) {
                 $this->deleteSession($conn);
                 $passes++;
             }

--- a/tests/Colopl/Spanner/SessionNotFoundTest.php
+++ b/tests/Colopl/Spanner/SessionNotFoundTest.php
@@ -1,0 +1,207 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Tests;
+
+use Colopl\Spanner\Connection;
+use Google\Cloud\Core\Exception\NotFoundException;
+use Google\Cloud\Spanner\Session\CacheSessionPool;
+use Illuminate\Database\QueryException;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+class SessionNotFoundTest extends TestCase
+{
+    private function deleteSession(Connection $connection)
+    {
+        // delete session on spanner side
+        $connection->getSpannerDatabase()->__debugInfo()['session']->delete();
+    }
+
+    public function testSessionNotFoundHandledError()
+    {
+        $conn = $this->getDefaultConnection();
+
+        $conn->selectOne('SELECT 1');
+
+        $this->deleteSession($conn);
+
+        $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
+    }
+
+    public function testInTransactionSessionNotFoundHandledError()
+    {
+        $conn = $this->getDefaultConnection();
+
+        $passes = 0;
+
+        $conn->transaction(function () use ($conn, &$passes) {
+
+            if ($passes == 0) {
+                $this->deleteSession($conn);
+                $passes++;
+            }
+
+            $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
+
+            $passes++;
+        });
+        $this->assertEquals(2, $passes, 'Transaction should be called twice');
+    }
+
+    public function testInTransactionCommitSessionNotFoundHandledError()
+    {
+        $conn = $this->getDefaultConnection();
+
+        $passes = 0;
+
+        $conn->transaction(function () use ($conn, &$passes) {
+
+            $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
+
+            if ($passes == 0) {
+                $this->deleteSession($conn);
+            }
+            $passes++;
+        });
+        $this->assertEquals(2, $passes, 'Transaction should be called twice');
+    }
+
+    public function testNestedTransactionsSessionNotFoundHandledError()
+    {
+        $conn = $this->getDefaultConnection();
+
+        $passes = 0;
+
+        $conn->transaction(function () use ($conn, &$passes) {
+            $conn->transaction(function () use ($conn, &$passes) {
+                $this->assertEquals(12345, $conn->selectOne('SELECT 12345')[0]);
+
+                if ($passes == 0) {
+                    $this->deleteSession($conn);
+                }
+                $passes++;
+            });
+        });
+        $this->assertEquals(2, $passes, 'Transaction should be called twice');
+    }
+
+    public function testCusrorSessionNotFoundHandledError()
+    {
+        $conn = $this->getDefaultConnection();
+
+        $passes = 0;
+
+        $conn->transaction(function () use ($conn, &$passes) {
+            $cursor = $conn->cursor('SELECT 12345');
+
+            if ($passes == 0) {
+                $this->deleteSession($conn);
+                $passes++;
+            }
+
+            $this->assertEquals(12345, $cursor->current()[0]);
+
+            $passes++;
+        });
+        $this->assertEquals(2, $passes, 'Transaction should be called twice');
+    }
+
+    public function testSessionNotFoundUnhandledError()
+    {
+        $config = $this->app['config']->get('database.connections.main');
+
+        // old behavior, just raise QueryException
+        $config['sessionNotFoundErrorMode'] = false;
+
+        $cacheItemPool = new ArrayAdapter();
+        $cacheSessionPool = new CacheSessionPool($cacheItemPool);
+        $conn = new Connection($config['instance'], $config['database'], '', $config, null, $cacheSessionPool);
+        $this->assertInstanceOf(Connection::class, $conn);
+
+        $conn->selectOne('SELECT 1');
+        $this->assertNotEmpty($cacheItemPool->getValues(), 'After executing some query, cache is created.');
+
+        // deliberately delete session on spanner side
+        $this->deleteSession($conn);
+
+        $this->expectException(QueryException::class);
+
+        // that string is used in sessionNotFoundWrapper() to catch session not found error,
+        // if google changes it then string should be changed in sessionNotFoundWrapper() as well
+        $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
+
+        $conn->selectOne('SELECT 1');
+    }
+
+    public function testCursorSessionNotFoundUnhandledError()
+    {
+        $config = $this->app['config']->get('database.connections.main');
+
+        // old behavior, just raise QueryException
+        $config['sessionNotFoundErrorMode'] = false;
+
+        $cacheItemPool = new ArrayAdapter();
+        $cacheSessionPool = new CacheSessionPool($cacheItemPool);
+        $conn = new Connection($config['instance'], $config['database'], '', $config, null, $cacheSessionPool);
+        $this->assertInstanceOf(Connection::class, $conn);
+
+        $cursor = $conn->cursor('SELECT 1');
+        $this->assertNotEmpty($cacheItemPool->getValues(), 'After executing some query, cache is created.');
+
+        // deliberately delete session on spanner side
+        $this->deleteSession($conn);
+
+        $this->expectException(NotFoundException::class);
+
+        // that string is used in sessionNotFoundWrapper() to catch session not found error,
+        // if google changes it then string should be changed in sessionNotFoundWrapper() as well
+        $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
+
+        iterator_to_array($cursor);
+    }
+
+    public function testInTransactionSessionNotFoundUnhandledError()
+    {
+        $config = $this->app['config']->get('database.connections.main');
+
+        // old behavior, just raise QueryException
+        $config['sessionNotFoundErrorMode'] = false;
+
+        $cacheItemPool = new ArrayAdapter();
+        $cacheSessionPool = new CacheSessionPool($cacheItemPool);
+        $conn = new Connection($config['instance'], $config['database'], '', $config, null, $cacheSessionPool);
+        $this->assertInstanceOf(Connection::class, $conn);
+
+        $this->expectException(NotFoundException::class);
+
+        // that string is used in sessionNotFoundWrapper() to catch session not found error,
+        // if google changes it then string should be changed in sessionNotFoundWrapper() as well
+        $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
+
+        $passes = 0;
+
+        $conn->transaction(function () use ($conn, &$passes) {
+
+            if ($passes == 0) {
+                $this->deleteSession($conn);
+                $passes++;
+            }
+
+            $conn->selectOne('SELECT 12345');
+        });
+    }
+}


### PR DESCRIPTION
fixes https://github.com/colopl/laravel-spanner/issues/37

There are a few cases when a 'Session not found' error can
[happen](https://cloud.google.com/spanner/docs/sessions#handle_deleted_sessions):

 - Scripts that idle too long - for example, a [Laravel queue worker](https://laravel.com/docs/9.x/queues#the-queue-work-command)
or anything that doesn't call Spanner frequently enough (more than once an hour).
 - The session is more than 28 days old.
 - Some random flukes on Google's side.
 
 