### PR TITLE
feat: use more descriptive naming for interleave

### DIFF
--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -177,13 +177,23 @@ class Blueprint extends BaseBlueprint
     }
 
     /**
+     * @deprecated use interleaveInParent instead.
      * @param string $parentTableName
      * @return InterleaveDefinition
      */
     public function interleave(string $parentTableName)
     {
+        return $this->interleaveInParent($parentTableName);
+    }
+
+    /**
+     * @param string $table
+     * @return InterleaveDefinition
+     */
+    public function interleaveInParent(string $table): InterleaveDefinition
+    {
         $command = new InterleaveDefinition(
-            $this->addCommand('interleave', compact('parentTableName'))->getAttributes()
+            $this->addCommand('interleaveInParent', compact('table'))->getAttributes()
         );
 
         $this->commands[count($this->commands) - 1] = $command;

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -157,8 +157,8 @@ class Grammar extends BaseGrammar
      */
     protected function addInterleaveToTable(Blueprint $blueprint)
     {
-        if (! is_null($command = $this->getCommandByName($blueprint, 'interleave'))) {
-            $schema = ", interleave in parent {$this->wrap($command->parentTableName)}";
+        if (! is_null($command = $this->getCommandByName($blueprint, 'interleaveInParent'))) {
+            $schema = ", interleave in parent {$this->wrap($command->table)}";
             if (! is_null($command->onDelete)) {
                 $schema .= " on delete {$command->onDelete}";
             }
@@ -239,7 +239,7 @@ class Grammar extends BaseGrammar
      */
     protected function addInterleaveToIndex(Fluent $indexCommand): string
     {
-        return empty($indexCommand->interleave) ? '' : ", interleave in {$this->wrap($indexCommand->interleave)}";
+        return empty($indexCommand->interleaveIn) ? '' : ", interleave in {$this->wrap($indexCommand->interleaveIn)}";
     }
 
     /**

--- a/src/Schema/IndexDefinition.php
+++ b/src/Schema/IndexDefinition.php
@@ -5,11 +5,20 @@ namespace Colopl\Spanner\Schema;
 use Illuminate\Support\Fluent;
 
 /**
- * @method $this interleave(string $table)
+ * @method $this interleaveIn(string $table)
  * @method $this nullFiltered()
  * @method $this storing(string[] $columns)
  * @extends Fluent<string, mixed>
  */
 class IndexDefinition extends Fluent
 {
+    /**
+     * @deprecated use interleaveIn instead.
+     * @param string $table
+     * @return $this
+     */
+    public function interleave(string $table)
+    {
+        return $this->interleaveIn($table);
+    }
 }

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -227,7 +227,7 @@ class BlueprintTest extends TestCase
             $table->string('name');
 
             $table->primary('userId');
-            $table->interleave('User');
+            $table->interleaveInParent('User');
         });
         $blueprint->create();
 
@@ -243,7 +243,7 @@ class BlueprintTest extends TestCase
             $table->string('name');
 
             $table->primary('userId');
-            $table->interleave('User')->cascadeOnDelete();
+            $table->interleaveInParent('User')->cascadeOnDelete();
         });
         $blueprint->create();
 
@@ -424,7 +424,7 @@ class BlueprintTest extends TestCase
         $conn = $this->getDefaultConnection();
 
         $blueprint = new Blueprint('UserItem', function (Blueprint $table) {
-            $table->index(['userId', 'createdAt'])->interleave('User');
+            $table->index(['userId', 'createdAt'])->interleaveIn('User');
         });
 
         $queries = $blueprint->toSql($conn, new Grammar());

--- a/tests/Schema/BuilderTest.php
+++ b/tests/Schema/BuilderTest.php
@@ -198,7 +198,7 @@ class BuilderTest extends TestCase
             $table->timestamps();
 
             $table->primary(['user_id', 'id']);
-            $table->interleave(self::TABLE_NAME_RELATION_PARENT_INTERLEAVED)->cascadeOnDelete();
+            $table->interleaveInParent(self::TABLE_NAME_RELATION_PARENT_INTERLEAVED)->cascadeOnDelete();
         });
 
         $this->assertTrue($sb->hasTable(self::TABLE_NAME_RELATION_PARENT_INTERLEAVED));


### PR DESCRIPTION
`Blueprint::interleave` -> `interleaveInParent`
`IndexDefinition::interleave` -> `interleaveIn`
