### PR TITLE
feature: change default sessionNotFoundErrorMode to CLEAR_SESSION_POOL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Changed
 - `Blueprint::stringArray`'s `$length` parameter is now optional and defaults to `255`.
 - Auth and session pool no longer use the custom FileCacheAdapter and uses Symfony's FilesystemAdapter instead.
 - Path for auth and session pool files have moved from `storage/framework/cache/spanner` to `storage/framework/spanner/{auth|session}`.
+- Default Session Not Found Error Mode was changed from `MAINTAIN_SESSION_POOL` to `CLEAR_SESSION_POOL` (wasn't fully confident at the time, but I think it should be safe to assume it's working now).
 
 # v4.4.0
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -450,7 +450,7 @@ class Connection extends BaseConnection
      */
     protected function getSessionNotFoundMode(): string
     {
-        return $this->config['sessionNotFoundErrorMode'] ?? self::MAINTAIN_SESSION_POOL;
+        return $this->config['sessionNotFoundErrorMode'] ?? self::CLEAR_SESSION_POOL;
     }
 
     /**


### PR DESCRIPTION
I wasn't fully confident at the time, but I think it should be safe to assume it's working now.