### PR TITLE
fix: match forceIndex arg with base class (added in laravel 9.52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
-# v4.5.1 Unreleased
+# v4.6.0 Unreleased
 
 Fixed
 - `Model::fresh` and `Model::refresh` now adds interleaved keys to the query.
+- Remove Type declaration from `Query/Builder::forceIndex()` to match the one added to laravel/framework in `v9.52.0`.
 
 # v4.5.0
 

--- a/src/Query/Concerns/AppliesForceIndex.php
+++ b/src/Query/Concerns/AppliesForceIndex.php
@@ -28,7 +28,7 @@ trait AppliesForceIndex
      * @param string|null $indexName
      * @return $this
      */
-    public function forceIndex(?string $indexName)
+    public function forceIndex($indexName)
     {
         $this->forceIndex = $indexName;
         return $this;


### PR DESCRIPTION
This package broke on laravel 9.52.0 since it introduced their own version of forceIndex, which has a different arg signature.