### PR TITLE
feature: update to laravel 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # v5.0.0 (Not Released Yet)
 
+updated composer.json to only support laravel 10
+
+Fixed
+- `Connection::reconnectIfMissingConnection` was changed from `protected` to `public` to match laravel 10.
+- [Query/Expression](https://laravel.com/docs/10.x/upgrade#database-expressions) changed from `(string)$expr`to `$expr->toValue($grammar)`.
+- Applied [QueryException constructor change](https://laravel.com/docs/10.x/upgrade#query-exception-constructor) to `Schema/Grammar`.
+
 Changed
 - Checks that primary key is defined in schema and throws an exception if not defined.
 - `Colopl\Spanner\Session` has been renamed to `Colopl\Spanner\SessionInfo`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ updated composer.json to only support laravel 10
 
 Fixed
 - `Connection::reconnectIfMissingConnection` was changed from `protected` to `public` to match laravel 10.
-- [Query/Expression](https://laravel.com/docs/10.x/upgrade#database-expressions) changed from `(string)$expr`to `$expr->toValue($grammar)`.
+- [Query/Expression](https://laravel.com/docs/10.x/upgrade#database-expressions) changed from `(string)$expr` to `$expr->getValue($grammar)`.
 - Applied [QueryException constructor change](https://laravel.com/docs/10.x/upgrade#query-exception-constructor) to `Schema/Grammar`.
 
 Changed

--- a/README.md
+++ b/README.md
@@ -285,7 +285,7 @@ or anything that doesn't call Spanner frequently enough (more than once an hour)
 
 The errors can be handled by one of the supported modes:
 
-- **MAINTAIN_SESSION_POOL** (default) - When the 'session not found' error is encountered, the library tries to disconnect,
+- **MAINTAIN_SESSION_POOL** - When the 'session not found' error is encountered, the library tries to disconnect,
 [maintain a session pool](https://github.com/googleapis/google-cloud-php/blob/077810260b58f5de8a3bbdfd999a5e9a48f71a7f/Spanner/src/Session/CacheSessionPool.php#L864)
 (to remove outdated sessions), reconnect, and then try querying again.
 The mode is enabled by default, but you can enable it explicitly via congifuration:
@@ -297,7 +297,7 @@ The mode is enabled by default, but you can enable it explicitly via congifurati
         ]
 ```
 
-- **CLEAR_SESSION_POOL** - The **MAINTAIN_SESSION_POOL** mode is tried first. If the error still happens, then
+- **CLEAR_SESSION_POOL** (default) - The **MAINTAIN_SESSION_POOL** mode is tried first. If the error still happens, then
 the [clearing of the session pool](https://github.com/googleapis/google-cloud-php/blob/077810260b58f5de8a3bbdfd999a5e9a48f71a7f/Spanner/src/Session/CacheSessionPool.php#L465)
 is enforced and the query is tried once again.
 As a consequence of session pool clearing, all processes that share the current session pool will be forced

--- a/composer.json
+++ b/composer.json
@@ -11,14 +11,14 @@
     "php": ">=8",
     "ext-grpc": "*",
     "ext-json": "*",
-    "laravel/framework": "~9.42",
+    "laravel/framework": "~10.0",
     "google/cloud-spanner": "^1.47",
     "grpc/grpc": "^1.42",
     "symfony/cache": "~6",
     "symfony/lock": "~6"
   },
   "require-dev": {
-    "orchestra/testbench": "~7",
+    "orchestra/testbench": "~8",
     "phpunit/phpunit": "~9.0",
     "phpstan/phpstan": "^1"
   },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: "#^Cannot cast mixed to string\\.$#"
-			count: 1
-			path: src/Schema/Grammar.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,5 +1,3 @@
-includes:
-  - phpstan-baseline.neon
 parameters:
     level: max
     checkMissingIterableValueType: false

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -26,8 +26,6 @@ parameters:
           path: src/Schema/Builder.php
         - message: '#^Property Illuminate\\Database\\Schema\\Builder::\$resolver \(Closure\) in isset\(\) is not nullable.$#'
           path: src/Schema/Builder.php
-        - message: '#^Parameter \#1 \$value of method Illuminate\\Database\\Schema\\Grammars\\Grammar::wrap\(\) expects Illuminate\\Database\\Query\\Expression\|string, Illuminate\\Database\\Schema\\ColumnDefinition given.$#'
-          path: src/Schema/Grammar.php
         - message: '#^Using nullsafe method call on non-nullable type Illuminate\\Database\\DatabaseTransactionsManager\. Use -> instead.$#'
           path: src/Concerns/ManagesTransactions.php
         - message: '#^Parameter \#1 \$connection of method Illuminate\\Database\\DatabaseTransactionsManager::.+\(\) expects string, string\|null given\.$#'

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -169,7 +169,7 @@ class Connection extends BaseConnection
     /**
      * @inheritDoc
      */
-    protected function reconnectIfMissingConnection()
+    public function reconnectIfMissingConnection()
     {
         if ($this->spannerDatabase === null) {
             $this->reconnect();
@@ -437,7 +437,12 @@ class Connection extends BaseConnection
         // message to include the bindings with SQL, which will make this exception a
         // lot more helpful to the developer instead of just the database's errors.
         catch (Exception $e) {
-            throw new QueryException($query, $this->prepareBindings($bindings), $e);
+            throw new QueryException(
+                $this->getName() ?? 'unknown',
+                $query,
+                $this->prepareBindings($bindings),
+                $e,
+            );
         }
 
         return $result;

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -21,7 +21,7 @@ use Colopl\Spanner\Concerns\MarksAsNotSupported;
 use Colopl\Spanner\Concerns\SharedGrammarCalls;
 use Colopl\Spanner\Query\Builder as SpannerBuilder;
 use Illuminate\Database\Query\Builder;
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Query\Grammars\Grammar as BaseGrammar;
 use RuntimeException;
 

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -147,7 +147,7 @@ class Blueprint extends BaseBlueprint
      */
     public function stringArray($column, $length = null)
     {
-        $length = $length ?: Builder::$defaultStringLength;
+        $length ??= Builder::$defaultStringLength;
 
         return $this->addColumn('array', $column, [
             'arrayType' => 'string',

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -508,7 +508,7 @@ class Grammar extends BaseGrammar
     protected function formatDefaultValue(Fluent $column, string $type, mixed $value): string
     {
         if ($value instanceof Expression) {
-            return (string) $this->getValue($value);
+            return $value->getValue($this);
         }
 
         // Match type without length or subtype.

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -34,9 +34,7 @@ class Grammar extends BaseGrammar
     use SharedGrammarCalls;
 
     /**
-     * The possible column modifiers.
-     *
-     * @var array
+     * @inheritdoc
      */
     protected $modifiers = ['Nullable', 'Default'];
 
@@ -503,9 +501,9 @@ class Grammar extends BaseGrammar
      * @param Fluent<string, mixed> $column
      * @param string $type
      * @param mixed $value
-     * @return string
+     * @return int|float|string
      */
-    protected function formatDefaultValue(Fluent $column, string $type, mixed $value): string
+    protected function formatDefaultValue(Fluent $column, string $type, mixed $value): int|float|string
     {
         if ($value instanceof Expression) {
             return $value->getValue($this);

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -20,7 +20,7 @@ namespace Colopl\Spanner\Schema;
 use Colopl\Spanner\Concerns\SharedGrammarCalls;
 use DateTimeInterface;
 use Illuminate\Database\Connection;
-use Illuminate\Database\Query\Expression;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Schema\Grammars\Grammar as BaseGrammar;
 use Illuminate\Support\Carbon;

--- a/tests/Schema/BuilderTest.php
+++ b/tests/Schema/BuilderTest.php
@@ -18,7 +18,6 @@
 namespace Colopl\Spanner\Tests\Schema;
 
 use Colopl\Spanner\Schema\Blueprint;
-use Colopl\Spanner\Schema\Builder;
 use Colopl\Spanner\Tests\TestCase;
 use Exception;
 use Illuminate\Support\Arr;


### PR DESCRIPTION

Fixed
- `Connection::reconnectIfMissingConnection` was changed from `protected` to `public` to match laravel 10.
- [Query/Expression](https://laravel.com/docs/10.x/upgrade#database-expressions) changed from `(string)$expr`to `$expr->toValue($grammar)`.
- Applied [QueryException constructor change](https://laravel.com/docs/10.x/upgrade#query-exception-constructor) to `Schema/Grammar`.
