### PR TITLE
fix: Expression should go through Grammar::getValue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
-# v4.6.1 (Not released yet)
+# v4.7.0 (Not released yet)
 
 Chore
 - Removed `ramsey/uuid` from composer.json since laravel already includes it.
+
+Fixed
+- Expressions given as $value in `Schema\Grammar::formatDefaultValue` will now go through `getValue` to match upstream (No behavioral change).
 
 # v4.6.0
 

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,6 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Cannot cast mixed to string\\.$#"
+			count: 1
+			path: src/Schema/Grammar.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,5 @@
+includes:
+  - phpstan-baseline.neon
 parameters:
     level: max
     checkMissingIterableValueType: false

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -508,7 +508,7 @@ class Grammar extends BaseGrammar
     protected function formatDefaultValue(Fluent $column, string $type, mixed $value): string
     {
         if ($value instanceof Expression) {
-            return (string)$value;
+            return (string) $this->getValue($value);
         }
 
         // Match type without length or subtype.


### PR DESCRIPTION
No change in behavior. Makes it easier to transition to laravel 10.