### PR TITLE
fix: FilesystemAdapter could not make 0777 directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,12 @@ Added
 
 Fixed
 - Fixed bug where running `Connection::statement` with DDLs was not logging and was not triggering events. (#86)
+- FilesystemAdapter was not creating the directory for the cache file with proper permissions. (#93)
 
 Changed
 - Use google-cloud-php's CacheSessionPool since the [concerned bug](https://github.com/googleapis/google-cloud-php/issues/5567) has been fixed in [v1.53](https://github.com/googleapis/google-cloud-php-spanner/releases/tag/v1.58.2). (#90)
 - Separate session pool and authentication per connection so transaction works properly. (#89)
+- SessionPool and AuthCache now writes to `storage/framework/spanner/{$name}-{auth|session}`. (#93)
 
 # v5.0.0
 

--- a/src/FileCacheAdapter.php
+++ b/src/FileCacheAdapter.php
@@ -1,0 +1,112 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner;
+
+use Generator;
+use RuntimeException;
+use Symfony\Component\Cache\Adapter\AbstractAdapter;
+use Symfony\Component\Cache\Marshaller\DefaultMarshaller;
+use Symfony\Component\Cache\Marshaller\MarshallerInterface;
+use Symfony\Component\Cache\PruneableInterface;
+use Symfony\Component\Cache\Traits\FilesystemCommonTrait;
+use Symfony\Component\Cache\Traits\FilesystemTrait;
+use function is_dir;
+use function mkdir;
+use function scandir;
+use function sprintf;
+use function umask;
+use const DIRECTORY_SEPARATOR;
+use const SCANDIR_SORT_NONE;
+
+class FileCacheAdapter extends AbstractAdapter implements PruneableInterface
+{
+    use FilesystemTrait;
+
+    /**
+     * @var string
+     */
+    protected string $name;
+
+    /**
+     * @param string $name
+     * @param string $directory
+     * @param MarshallerInterface|null $marshaller
+     */
+    public function __construct(string $name, string $directory, MarshallerInterface $marshaller = null)
+    {
+        $this->marshaller = $marshaller ?? new DefaultMarshaller();
+        parent::__construct($name);
+        $this->name = $name;
+        $this->directory = $directory.DIRECTORY_SEPARATOR;
+        $this->ensureDirectory();
+    }
+
+    /**
+     * @return void
+     */
+    protected function ensureDirectory(): void
+    {
+        if (!is_dir($this->directory)) {
+            // umask must be set to 0000 inorder to create cache directory with 0777 permission.
+            // writing as 0777 ensures that web-server user and cli user can both read/write to the same cache directory.
+            // This is important because we want to be able to warm up the cache from cli and use it from web-server.
+            $umask = umask(0);
+            @mkdir($this->directory, 0777, true);
+            umask($umask);
+            if (!is_dir($this->directory)) {
+                throw new RuntimeException(sprintf('Impossible to create the root directory "%s".', $this->directory));
+            }
+        }
+    }
+
+    /**
+     * OVERRIDE implementation from FilesystemCommonTrait since our directory structure differs from one provided
+     * @see FilesystemCommonTrait::getFile()
+     *
+     * @param string $id
+     * @param bool $mkdir
+     * @return string
+     */
+    protected function getFile(string $id, bool $mkdir = false): string
+    {
+        if ($mkdir) {
+            $this->ensureDirectory();
+        }
+        return $this->directory.$this->name;
+    }
+
+    /**
+     * OVERRIDE implementation from FilesystemCommonTrait since our directory structure differs from one provided
+     * @see FilesystemCommonTrait::scanHashDir()
+     *
+     * @param string $directory
+     * @return Generator
+     */
+    protected function scanHashDir(string $directory): Generator
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        foreach (@scandir($directory, SCANDIR_SORT_NONE) ?: [] as $file) {
+            if ('.' !== $file && '..' !== $file) {
+                yield $directory . DIRECTORY_SEPARATOR . $file;
+            }
+        }
+    }
+}

--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -27,7 +27,6 @@ use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
 use Psr\Cache\CacheItemPoolInterface;
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
 class SpannerServiceProvider extends ServiceProvider
 {
@@ -93,9 +92,8 @@ class SpannerServiceProvider extends ServiceProvider
      */
     protected function createSessionPool(string $name, array $sessionPoolConfig): SessionPoolInterface
     {
-        $cachePath = storage_path(implode(DIRECTORY_SEPARATOR, ['framework', 'spanner', $name]));
-        $adapter = new FilesystemAdapter('session', 0, $cachePath);
-        return new CacheSessionPool($adapter, $sessionPoolConfig);
+        $cachePath = $this->app->storagePath(implode(DIRECTORY_SEPARATOR, ['framework', 'spanner']));
+        return new CacheSessionPool(new FileCacheAdapter("{$name}-session", $cachePath), $sessionPoolConfig);
     }
 
     /**
@@ -104,8 +102,8 @@ class SpannerServiceProvider extends ServiceProvider
      */
     protected function createAuthCache(string $name): CacheItemPoolInterface
     {
-        $cachePath = storage_path(implode(DIRECTORY_SEPARATOR, ['framework', 'spanner', $name]));
-        return new FilesystemAdapter('auth', 0, $cachePath);
+        $cachePath = $this->app->storagePath(implode(DIRECTORY_SEPARATOR, ['framework', 'spanner']));
+        return new FileCacheAdapter("{$name}-auth", $cachePath);
     }
 
     protected function closeSessionAfterEachQueueJob(): void

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -249,7 +249,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getDefaultConnection();
         $conn->select('SELECT 1');
-        self::assertDirectoryExists(storage_path("framework/spanner/{$conn->getName()}/auth"));
+        self::assertFileExists(storage_path("framework/spanner/{$conn->getName()}-auth"));
     }
 
     public function testSessionPool(): void
@@ -272,7 +272,7 @@ class ConnectionTest extends TestCase
     {
         $conn = $this->getDefaultConnection();
         $conn->select('SELECT 1');
-        self::assertDirectoryExists(storage_path("framework/spanner/{$conn->getName()}/session"));
+        self::assertFileExists(storage_path("framework/spanner/{$conn->getName()}-session"));
     }
 
     public function test_clearSessionPool(): void

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -38,6 +38,11 @@ use Illuminate\Database\Events\TransactionCommitted;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Event;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use function dirname;
+use function fileperms;
+use function mkdir;
+use function sprintf;
+use function substr;
 
 class ConnectionTest extends TestCase
 {
@@ -247,9 +252,15 @@ class ConnectionTest extends TestCase
 
     public function test_AuthCache_with_FileSystemAdapter(): void
     {
+        $this->app->useStoragePath('/tmp/laravel-spanner');
+
         $conn = $this->getDefaultConnection();
         $conn->select('SELECT 1');
-        self::assertFileExists(storage_path("framework/spanner/{$conn->getName()}-auth"));
+
+        $outputPath = $this->app->storagePath("framework/spanner/{$conn->getName()}-auth");
+        self::assertFileExists($outputPath);
+        self::assertSame('0777', substr(sprintf('%o', fileperms(dirname($outputPath))), -4));
+        self::assertSame('0644', substr(sprintf('%o', fileperms($outputPath)), -4));
     }
 
     public function testSessionPool(): void
@@ -270,9 +281,15 @@ class ConnectionTest extends TestCase
 
     public function test_session_pool_with_FileSystemAdapter(): void
     {
+        $this->app->useStoragePath('/tmp/laravel-spanner');
+
         $conn = $this->getDefaultConnection();
         $conn->select('SELECT 1');
-        self::assertFileExists(storage_path("framework/spanner/{$conn->getName()}-session"));
+
+        $outputPath = $this->app->storagePath("framework/spanner/{$conn->getName()}-session");
+        self::assertFileExists($outputPath);
+        self::assertSame('0777', substr(sprintf('%o', fileperms(dirname($outputPath))), -4));
+        self::assertSame('0644', substr(sprintf('%o', fileperms($outputPath)), -4));
     }
 
     public function test_clearSessionPool(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -25,6 +25,9 @@ use Google\Cloud\Spanner\SpannerClient;
 use Illuminate\Foundation\Application;
 use Ramsey\Uuid\Uuid;
 
+/**
+ * @property Application $app
+ */
 abstract class TestCase extends \Orchestra\Testbench\TestCase
 {
     protected const TABLE_NAME_TEST = 'Test';


### PR DESCRIPTION
Reverts part of #63

Default umask for alpine linux is `0022` which forces directories to be created with permissions `0755`.

Since `spanner:warmup` is usually called from the cli, the cache directory is usually created by the cli user.
When a www user tries to use spanner, it will attempt to create a file in the cache directory but will get a permission denied error since the created directory has the permission `0755` and not `0777`.

This fix will set the umask to `0000` before creating the directory so it can be created with permission `0777`.

Test is lacking but there is no way to test 2 different users writing to a file through phpunit.