### PR TITLE
Fix incorrect and weak requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Laravel database driver for Google Cloud Spanner
 
 ## Requirements
 
-- PHP >= 8.0
+- PHP >= 8.1
 - Laravel >= 10
 - [gRPC extension](https://cloud.google.com/php/grpc)
 - [protobuf extension](https://cloud.google.com/php/grpc#install_the_protobuf_runtime_library) (not required, but strongly recommended)

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     {"name": "Takayasu Oyama", "email": "t-oyama@colopl.co.jp"}
   ],
   "require": {
-    "php": "~8.1.0 || ~8.2.0",
+    "php": "^8.1",
     "ext-grpc": "*",
     "ext-json": "*",
     "laravel/framework": "~10.0",

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     {"name": "Takayasu Oyama", "email": "t-oyama@colopl.co.jp"}
   ],
   "require": {
-    "php": ">=8",
+    "php": "~8.1.0 || ~8.2.0",
     "ext-grpc": "*",
     "ext-json": "*",
     "laravel/framework": "~10.0",


### PR DESCRIPTION
Fix: #94 

P.S. Due to the nature of being hosted on Packagist, it is necessary to cancel the v5.0.0 release. Otherwise, it will be installed improperly in the event of future incompatibility with minor PHP upgrades.