### PR TITLE
Update `export-ignore` entries in `.gitattributes`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,9 +1,12 @@
 * text=auto
 
+/.github/ export-ignore
 /tests export-ignore
 .env.sample export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
+compose.yaml export-ignore
+phpstan.neon export-ignore
 phpunit.xml export-ignore
 Dockerfile export-ignore
 docker-compose.yml export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ Added
 
 Changed
 - `Connection::waitForOperation` and `Connection::isDoneOperation` has been removed. (#99)
+- Update `export-ignore` entries in `.gitattributes` (#104)
 
 # v5.1.0
 


### PR DESCRIPTION
Added `/.github/`, `compose.yaml`, & `phpstan.neon` as `export-ignore`.
These are just needed for developing. 

## Checklist

- [x] CHANGELOG


