### PR TITLE
fix: Transaction state was not being cleared if rolled back failed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changed
 - `Connection::waitForOperation` and `Connection::isDoneOperation` has been removed. (#99)
 - Update `export-ignore` entries in `.gitattributes` (#104)
 
+Fixed
+- Transaction state was not being cleared if rolled back failed. (#106)
+
 # v5.1.0
 
 Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ Changed
 - Update `export-ignore` entries in `.gitattributes` (#104)
 
 Fixed
-- Transaction state was not being cleared if rolled back failed. (#106)
+- Transaction state was not being cleared if rolled back failed. (#107)
 
 # v5.1.0
 

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -214,11 +214,9 @@ trait ManagesTransactions
      */
     protected function handleRollbackException(Throwable $e)
     {
-        if ($e instanceof NotFoundException) {
-            // Must be reset so that transaction can be retried.
-            // otherwise, transactions will remain at 1.
-            $this->transactions = 0;
-        }
+        // Must be reset so that transaction can be retried.
+        // otherwise, transactions will remain at 1.
+        $this->transactions = 0;
 
         throw $e;
     }


### PR DESCRIPTION
NOTE: Needs to be backported to v4.7.x.