### PR TITLE
DX: optimize build local container image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ ENV PATH="${PATH}:/project/vendor/bin"
 # Fix for Alpine Linux 3.13 https://github.com/grpc/grpc/issues/25250
 ENV CPPFLAGS="-Wno-maybe-uninitialized"
 
+# pecl_mt_install: `pecl` does not support multi-threaded compile, so it compiles on manually for speedup.
 RUN pecl_mt_install() { \
         extension="${1}" \
         && extension_name="${extension%-*}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ ENV PATH="${PATH}:/project/vendor/bin"
 # Fix for Alpine Linux 3.13 https://github.com/grpc/grpc/issues/25250
 ENV CPPFLAGS="-Wno-maybe-uninitialized"
 
-# pecl_mt_install: `pecl` does not support multi-threaded compile, so it compiles on manually for speedup.
+# pecl_mt_install: `pecl install` does not support multi-threaded compile, so install manually for faster compilation.
 RUN pecl_mt_install() { \
         extension="${1}" \
         && extension_name="${extension%-*}" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM php:8.1-cli-alpine
 
+COPY --from=composer:2 /usr/bin/composer /usr/bin/composer
+
 ENV COMPOSER_ALLOW_SUPERUSER 1
 ENV TZ Asia/Tokyo
 ENV PATH="${PATH}:/project/vendor/bin"
@@ -14,7 +16,6 @@ RUN apk add --no-cache bash gmp libxml2 libstdc++ \
   && docker-php-ext-enable grpc opcache protobuf \
   && apk del .build-deps \
   && rm -rf /tmp/* \
-  && curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin/ --filename=composer \
   && mkdir -p /project/
 
 WORKDIR /project

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,10 +9,35 @@ ENV PATH="${PATH}:/project/vendor/bin"
 # Fix for Alpine Linux 3.13 https://github.com/grpc/grpc/issues/25250
 ENV CPPFLAGS="-Wno-maybe-uninitialized"
 
-RUN apk add --no-cache bash gmp libxml2 libstdc++ \
+RUN pecl_mt_install() { \
+        extension="${1}" \
+        && extension_name="${extension%-*}" \
+        && shift \
+        && configure_option=${@:1} \
+        && temporary="/tmp/pear/temp/${extension_name}" \
+        && apk_delete="" \
+        && if [ -n "${PHPIZE_DEPS}" ] && ! apk info --installed .phpize-deps > /dev/null; then \
+            apk add --no-cache --virtual .phpize-deps ${PHPIZE_DEPS}; \
+            apk_delete='.phpize-deps'; \
+        fi \
+        && if [ -n "${HTTP_PROXY:-}" ]; then \
+            pear config-set http_proxy ${HTTP_PROXY}; \
+        fi \
+        && pecl install --onlyreqdeps --nobuild "${extension}" \
+        && cd "${temporary}" \
+          && phpize \
+          && CFLAGS="${PHP_CFLAGS:-}" CPPFLAGS="${PHP_CPPFLAGS:-}" CXXFLAGS="${PHP_CXXFLAGS:-}" LDFLAGS="${PHP_LDFLAGS:-}" ./configure ${configure_option} \
+          && make -j$(nproc) \
+          && make install \
+        && cd - \
+        && rm -rf "${temporary}" \
+        && if [ -n "${apk_delete}" ]; then apk del --purge --no-network ${apk_delete}; fi \
+      } \
+  && apk add --no-cache bash gmp libxml2 libstdc++ \
   && apk add --no-cache --virtual=.build-deps autoconf curl-dev gcc gmp-dev g++ libxml2-dev linux-headers make pcre-dev tzdata \
   && docker-php-ext-install -j$(nproc) bcmath gmp \
-  && pecl install -o -f protobuf grpc \
+  && pecl_mt_install protobuf \
+  && pecl_mt_install grpc \
   && docker-php-ext-enable grpc opcache protobuf \
   && apk del .build-deps \
   && rm -rf /tmp/* \


### PR DESCRIPTION
gRPC is a very large extension and takes a long time to compile. Use parallel compilation to speed up the setup of local environment.

Composer also changed because it is faster to retrieve from a pre-built image.

## Checklist

~- [ ] CHANGELOG~

