### PR TITLE
fix: escape list for Query/Builder::toRawSql

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v5.2.1 (Not released yet)
+
+Fixed
+- Escape list for `Query/Builder::toRawSql` (#127)
+
 # v5.2.0
 
 Added

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -37,6 +37,8 @@ use Google\Cloud\Spanner\Transaction;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Database\QueryException;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use Psr\Cache\CacheItemPoolInterface;
@@ -418,6 +420,22 @@ class Connection extends BaseConnection
         }
 
         return $bindings;
+    }
+
+    /**
+     * @inheritDoc
+     * @param scalar|list<mixed>|null $value
+     */
+    public function escape($value, $binary = false)
+    {
+        if (is_array($value)) {
+            if (array_is_list($value)) {
+                $escaped = array_map(fn (mixed $v): string => $this->escape($v, $binary), $value);
+                return '[' . implode(', ', $escaped) . ']';
+            }
+            throw new LogicException('Associative arrays are not supported');
+        }
+        return parent::escape($value, $binary);
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -37,8 +37,6 @@ use Google\Cloud\Spanner\Transaction;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Connection as BaseConnection;
 use Illuminate\Database\QueryException;
-use Illuminate\Support\Arr;
-use Illuminate\Support\Str;
 use InvalidArgumentException;
 use LogicException;
 use Psr\Cache\CacheItemPoolInterface;

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -502,4 +502,13 @@ class ConnectionTest extends TestCase
         self::assertSame('[1]', $conn->escape([1]));
         self::assertSame('[1.1]', $conn->escape([1.1]));
     }
+
+    public function test_escape_nested_array(): void
+    {
+        $this->expectExceptionMessage('Nested arrays are not supported by Cloud Spanner');
+        $this->expectException(LogicException::class);
+
+        $conn = $this->getDefaultConnection();
+        self::assertSame('[]', $conn->escape([[]]));
+    }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -19,6 +19,7 @@ namespace Colopl\Spanner\Tests;
 
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Events\MutatingData;
+use Colopl\Spanner\Schema\Blueprint;
 use Colopl\Spanner\Session\SessionInfo;
 use Colopl\Spanner\TimestampBound\ExactStaleness;
 use Colopl\Spanner\TimestampBound\MaxStaleness;
@@ -423,7 +424,7 @@ class ConnectionTest extends TestCase
         $this->assertEquals(TransactionCommitted::class, $receivedEventClasses[2]);
     }
 
-    public function test_Connection_transaction_reset_on_exceptions(): void
+    public function test_connection_transaction_reset_on_exceptions(): void
     {
         $conn = $this->getDefaultConnection();
 
@@ -481,5 +482,24 @@ class ConnectionTest extends TestCase
         self::assertfalse($conn->inTransaction());
         self::assertNull($conn->getCurrentTransaction());
         self::assertSame(0, $conn->transactionLevel());
+    }
+
+    public function test_escape(): void
+    {
+        $conn = $this->getDefaultConnection();
+
+        self::assertSame('true', $conn->escape(true));
+        self::assertSame('false', $conn->escape(false));
+        self::assertSame('1', $conn->escape(1));
+        self::assertSame('0', $conn->escape(0));
+        self::assertSame('-1', $conn->escape(-1));
+        self::assertSame('1.1', $conn->escape(1.1));
+        self::assertSame('"a"', $conn->escape('a'));
+        self::assertSame('r"""' . "\n" . '"""', $conn->escape("\n"));
+        self::assertSame('[]', $conn->escape([]));
+        self::assertSame('["a"]', $conn->escape(['a']));
+        self::assertSame('[false]', $conn->escape([false]));
+        self::assertSame('[1]', $conn->escape([1]));
+        self::assertSame('[1.1]', $conn->escape([1.1]));
     }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -897,8 +897,5 @@ class BuilderTest extends TestCase
 
         $sql = $conn->table($table)->where('s', "t\"e\"s\nt")->toRawSql();
         $this->assertSame("select * from `RawSqlTest` where `s` = r\"\"\"t\\\"e\\\"s\nt\"\"\"", $sql, 'newline with escaped quote');
-
-        $sql = $conn->table($table)->insert([]);
-        $this->assertSame('select * from `RawSqlTest` where `a` = []', $sql, 'true');
     }
 }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -20,6 +20,7 @@ namespace Colopl\Spanner\Tests\Query;
 use BadMethodCallException;
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Query\Builder;
+use Colopl\Spanner\Schema\Blueprint;
 use Colopl\Spanner\Tests\TestCase;
 use Colopl\Spanner\TimestampBound\ExactStaleness;
 use Google\Cloud\Spanner\Bytes;
@@ -870,24 +871,34 @@ class BuilderTest extends TestCase
 
     public function test_toRawSql(): void
     {
+        $table = 'RawSqlTest';
         $conn = $this->getDefaultConnection();
 
-        $sql = $conn->table(self::TABLE_NAME_USER)->where('b', true)->toRawSql();
-        $this->assertSame($sql, 'select * from `User` where `b` = true', 'true');
+        $sql = $conn->table($table)->where('b', true)->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `b` = true', $sql, 'true');
 
-        $sql = $conn->table(self::TABLE_NAME_USER)->where('b', false)->toRawSql();
-        $this->assertSame($sql, 'select * from `User` where `b` = false', 'false');
+        $sql = $conn->table($table)->where('b', false)->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `b` = false', $sql, 'false');
 
-        $sql = $conn->table(self::TABLE_NAME_USER)->where('t', 'test')->toRawSql();
-        $this->assertSame($sql, 'select * from `User` where `t` = "test"', 'text');
+        $sql = $conn->table($table)->where('i', 1)->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `i` = 1', $sql, 'text');
 
-        $sql = $conn->table(self::TABLE_NAME_USER)->where('t', '"tes\'s"')->toRawSql();
-        $this->assertSame($sql, 'select * from `User` where `t` = "\"tes\'s\""', 'escaped');
+        $sql = $conn->table($table)->where('f', 1.1)->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `f` = 1.1', $sql, 'text');
 
-        $sql = $conn->table(self::TABLE_NAME_USER)->where('t', "tes\nt")->toRawSql();
-        $this->assertSame($sql, "select * from `User` where `t` = r\"\"\"tes\nt\"\"\"", 'newline');
+        $sql = $conn->table($table)->where('s', 'test')->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `s` = "test"', $sql, 'text');
 
-        $sql = $conn->table(self::TABLE_NAME_USER)->where('t', "t\"e\"s\nt")->toRawSql();
-        $this->assertSame($sql, "select * from `User` where `t` = r\"\"\"t\\\"e\\\"s\nt\"\"\"", 'newline with escaped quote');
+        $sql = $conn->table($table)->where('s', '"tes\'s"')->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `s` = "\"tes\'s\""', $sql, 'escaped');
+
+        $sql = $conn->table($table)->where('s', "tes\nt")->toRawSql();
+        $this->assertSame("select * from `RawSqlTest` where `s` = r\"\"\"tes\nt\"\"\"", $sql, 'newline');
+
+        $sql = $conn->table($table)->where('s', "t\"e\"s\nt")->toRawSql();
+        $this->assertSame("select * from `RawSqlTest` where `s` = r\"\"\"t\\\"e\\\"s\nt\"\"\"", $sql, 'newline with escaped quote');
+
+        $sql = $conn->table($table)->insert([]);
+        $this->assertSame('select * from `RawSqlTest` where `a` = []', $sql, 'true');
     }
 }


### PR DESCRIPTION
Spanner bindings can also include list values.