### PR TITLE
[5.2] fix: sessions were not cleared in some test cases

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -107,7 +107,7 @@ class Connection extends BaseConnection
      * @param string $instanceId instance ID
      * @param string $database
      * @param string $tablePrefix
-     * @param array $config
+     * @param array<string, mixed> $config
      * @param CacheItemPoolInterface|null $authCache
      * @param SessionPoolInterface|null $sessionPool
      */

--- a/tests/Concerns/ManagesDataDefinitionsTest.php
+++ b/tests/Concerns/ManagesDataDefinitionsTest.php
@@ -51,7 +51,7 @@ class ManagesDataDefinitionsTest extends TestCase
         if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
             $this->setUpEmulatorInstance($conn);
         }
-        $this->beforeApplicationDestroyed(fn () => $conn->clearSessionPool());
+        $this->beforeApplicationDestroyed(static fn () => $conn->clearSessionPool());
 
         $conn->setEventDispatcher($events);
         $conn->enableQueryLog();

--- a/tests/Concerns/ManagesDataDefinitionsTest.php
+++ b/tests/Concerns/ManagesDataDefinitionsTest.php
@@ -51,6 +51,7 @@ class ManagesDataDefinitionsTest extends TestCase
         if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
             $this->setUpEmulatorInstance($conn);
         }
+        $this->beforeApplicationDestroyed(fn () => $conn->clearSessionPool());
 
         $conn->setEventDispatcher($events);
         $conn->enableQueryLog();

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -19,7 +19,6 @@ namespace Colopl\Spanner\Tests;
 
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Events\MutatingData;
-use Colopl\Spanner\Schema\Blueprint;
 use Colopl\Spanner\Session\SessionInfo;
 use Colopl\Spanner\TimestampBound\ExactStaleness;
 use Colopl\Spanner\TimestampBound\MaxStaleness;
@@ -44,7 +43,6 @@ use RuntimeException;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 use function dirname;
 use function fileperms;
-use function mkdir;
 use function sprintf;
 use function substr;
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -290,7 +290,8 @@ class ConnectionTest extends TestCase
         $config = $this->app['config']->get('database.connections.main');
 
         $authCache = new ArrayAdapter();
-        $conn = new Connection($config['instance'], $config['database'], '', $config, $authCache);
+        $sessionPool = new CacheSessionPool(new ArrayAdapter());
+        $conn = new Connection($config['instance'], $config['database'], '', $config, $authCache, $sessionPool);
         $this->setUpDatabaseOnce($conn);
 
         $conn->selectOne('SELECT 1');
@@ -312,13 +313,14 @@ class ConnectionTest extends TestCase
         self::assertSame('0644', substr(sprintf('%o', fileperms($outputPath)), -4));
     }
 
-    public function testSessionPool(): void
+    public function test_session_pool(): void
     {
         $config = $this->app['config']->get('database.connections.main');
 
         $cacheItemPool = new ArrayAdapter();
         $cacheSessionPool = new CacheSessionPool($cacheItemPool);
         $conn = new Connection($config['instance'], $config['database'], '', $config, null, $cacheSessionPool);
+        $this->setUpDatabaseOnce($conn);
         $this->assertInstanceOf(Connection::class, $conn);
 
         $conn->selectOne('SELECT 1');
@@ -359,7 +361,7 @@ class ConnectionTest extends TestCase
         $this->assertInstanceOf(SessionInfo::class, $sessions[0]);
     }
 
-    public function testStaleReads(): void
+    public function test_stale_reads(): void
     {
         $conn = $this->getDefaultConnection();
         $tableName = self::TABLE_NAME_USER;
@@ -373,6 +375,7 @@ class ConnectionTest extends TestCase
             $tx->executeUpdate("INSERT INTO ${tableName} (`userId`, `name`) VALUES ('${uuid}', '${name}')");
             $timestamp = $tx->commit();
         });
+        $db->close();
         $this->assertNotEmpty($timestamp);
 
         $timestampBound = new StrongRead();

--- a/tests/SessionNotFoundTest.php
+++ b/tests/SessionNotFoundTest.php
@@ -41,7 +41,6 @@ class SessionNotFoundTest extends TestCase
         $cacheItemPool = new ArrayAdapter();
         $cacheSessionPool = new CacheSessionPool($cacheItemPool);
         $conn = new Connection($config['instance'], $config['database'], '', $config, null, $cacheSessionPool);
-
         $this->setUpDatabaseOnce($conn);
         return $conn;
     }
@@ -170,7 +169,13 @@ class SessionNotFoundTest extends TestCase
         // if google changes it then string should be changed in Connection::SESSION_NOT_FOUND_CONDITION
         $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
 
-        $conn->selectOne('SELECT 1');
+        try {
+            $conn->selectOne('SELECT 1');
+        } catch (QueryException $e) {
+            $conn->disconnect();
+            $conn->clearSessionPool();
+            throw $e;
+        }
     }
 
     public function testCursorSessionNotFoundUnhandledError(): void
@@ -188,7 +193,13 @@ class SessionNotFoundTest extends TestCase
         // if google changes it then string should be changed in Connection::SESSION_NOT_FOUND_CONDITION
         $this->expectExceptionMessage($conn::SESSION_NOT_FOUND_CONDITION);
 
-        iterator_to_array($cursor);
+        try {
+            iterator_to_array($cursor);
+        } catch (NotFoundException $e) {
+            $conn->disconnect();
+            $conn->clearSessionPool();
+            throw $e;
+        }
     }
 
     public function testInTransactionSessionNotFoundUnhandledError(): void

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -110,10 +110,9 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
 
     /**
      * @param Connection $conn
-     * @param bool $clearSessionPool
      * @return void
      */
-    protected function setUpDatabaseOnce(Connection $conn, bool $clearSessionPool = true): void
+    protected function setUpDatabaseOnce(Connection $conn): void
     {
         if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
             $this->setUpEmulatorInstance($conn);
@@ -121,14 +120,7 @@ abstract class TestCase extends \Orchestra\Testbench\TestCase
         if (!$conn->databaseExists()) {
             $conn->createDatabase($this->getTestDatabaseDDLs());
         }
-        if ($clearSessionPool) {
-            $this->beforeApplicationDestroyed(fn () => $this->cleanupDatabase($conn));
-        }
-        $sessions = $conn->listSessions();
-        if ($sessions->isNotEmpty()) {
-            dump($this->name());
-            dump($sessions);
-        }
+        $this->beforeApplicationDestroyed(fn () => $this->cleanupDatabase($conn));
     }
 
     /**


### PR DESCRIPTION
Currently, there are dangling sessions after the test runs, which results in unstable results for `spanner:sessions` command.

This fix will delete sessions on the server side, whenever a test creates a new session.
