### PR TITLE
[5.2] fix: queries should be retried when session pool is undefined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
+# v5.2.2 (2023-08-22)
+
+Fixed
+- Fixed a case where queries were not being retried on "Session Not Found" errors when session pool is undefined (#129)
+
 # v5.2.1 (2023-08-16)
 
 Fixed
 - Escape list for `Query/Builder::toRawSql` (#127)
-- Fixed a case where queries were not being retried on "Session Not Found" errors when session pool is undefined (#129)
 
 # v5.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 Fixed
 - Escape list for `Query/Builder::toRawSql` (#127)
+- Fixed a case where queries were not being retried on "Session Not Found" errors when session pool is undefined (#129)
 
 # v5.2.0
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -532,10 +532,7 @@ class Connection extends BaseConnection
             throw new InvalidArgumentException("Unsupported sessionNotFoundErrorMode [{$handlerMode}].");
         }
 
-        if ($handlerMode === self::THROW_EXCEPTION
-            || $this->sessionPool === null
-            || $this->inTransaction()
-        ) {
+        if ($handlerMode === self::THROW_EXCEPTION || $this->inTransaction()) {
             // skip handlers, transaction() will handle error by self
             return $callback();
         }


### PR DESCRIPTION
Previously, if session pool was not set, nothing was being handled, but that results in stale connection.
The connection should be reconnected so that the missing session can be discarded.