### PR TITLE
[6.0] feat: remove Session Not Found Error Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Added
 
 Changed
 - [Breaking] Match `Query\Builder::forceIndex()` behavior with laravel's (`forceIndex` property no longer exists). (#114)
-- [Breaking] SessionNotFoundErrorMode was removed and will always run clear session pool. (#) (#114)
+- [Breaking] SessionNotFoundErrorMode was removed and will always run clear session pool. (#132) (#130)
 
 # v5.2.2 (2023-08-22)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Added
 
 Changed
 - [Breaking] Match `Query\Builder::forceIndex()` behavior with laravel's (`forceIndex` property no longer exists). (#114)
-- [Breaking] SessionNotFoundErrorMode's `MAINTAIN_SESSION_POOL` was removed since we're now certain [it doesn't work](https://github.com/googleapis/google-cloud-php/issues/6284#issuecomment-1665394907). (#114)
+- [Breaking] SessionNotFoundErrorMode was removed and will always run clear session pool. (#) (#114)
 
 # v5.2.2 (2023-08-22)
 


### PR DESCRIPTION
There is no need for the user to "switch modes" because I found out that retrying is the expected behavior by the [Spanner Team](https://github.com/googleapis/google-cloud-java/pull/4734).

- [x] CHANGELOG
