### PR TITLE
fix: explicitly stage transaction to correctly run afterCommit jobs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ Changed
 - [Breaking] SessionNotFoundErrorMode was removed and will always run clear session pool. (#132) (#130)
 - [Breaking] Auth cache and Session pool now share the same file cache adapter (#139)
 
+Fixed
+- Explicitly stage/clear transaction on commit to correctly run afterCommit jobs in Laravel >= [v10.32.0](https://github.com/laravel/framework/pull/48859) (#144)
+
 # v5.2.2 (2023-08-22)
 
 Fixed

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.1",
     "ext-grpc": "*",
     "ext-json": "*",
-    "laravel/framework": "~10.0",
+    "laravel/framework": "^10.32.0",
     "google/cloud-spanner": "^1.58.4",
     "grpc/grpc": "^1.42",
     "symfony/cache": "~6",

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -141,6 +141,8 @@ trait ManagesTransactions
             $this->currentTransaction->commit();
         }
 
+        $this->transactionsManager?->stageTransactions($this->getName());
+
         $this->transactions = max(0, $this->transactions - 1);
         if ($this->isTransactionFinished()) {
             $this->currentTransaction = null;


### PR DESCRIPTION
Laravel v10.32.0 requires explicit staging/clearing of transactions https://github.com/laravel/framework/pull/48859
without this code afterCommit jobs are never sent 

Fix: #

## Checklist

- [x] CHANGELOG

## Reference

