### PR TITLE
fix: separate auth cache and session pool to prevent race condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# v6.1.0 (Not Released Yet)
+# v6.1.1 (Not Released Yet)
+
+Fixed
+- Bug where auth and session pool writing to the same file may cause race condition (#152)
+
+# v6.1.0 (2023-11-29)
 
 Added
 - Add support for [NUMERIC](https://cloud.google.com/spanner/docs/reference/standard-sql/data-types#numeric_type) column type. (#145)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,3 +35,6 @@ parameters:
         - message: '#^Property Colopl\\Spanner\\Session\\SessionInfo\:\:\$labels \(array\<string, string\>\) does not accept array\.$#'
           path: src/Session/SessionInfo.php
           count: 1
+        - message: "#^Method Colopl\\\\Spanner\\\\SpannerServiceProvider\\:\\:parseConfig\\(\\) should return array\\{name\\: string, instance\\: string, database\\: string, prefix\\: string, cache_path\\: string, session_pool\\: array\\<string, mixed\\>\\} but returns non\\-empty\\-array\\<string, mixed\\>\\.$#"
+          count: 1
+          path: src/SpannerServiceProvider.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -35,6 +35,6 @@ parameters:
         - message: '#^Property Colopl\\Spanner\\Session\\SessionInfo\:\:\$labels \(array\<string, string\>\) does not accept array\.$#'
           path: src/Session/SessionInfo.php
           count: 1
-        - message: "#^Method Colopl\\\\Spanner\\\\SpannerServiceProvider\\:\\:parseConfig\\(\\) should return array\\{name\\: string, instance\\: string, database\\: string, prefix\\: string, cache_path\\: string, session_pool\\: array\\<string, mixed\\>\\} but returns non\\-empty\\-array\\<string, mixed\\>\\.$#"
+        - message: "#^Method Colopl\\\\Spanner\\\\SpannerServiceProvider\\:\\:parseConfig\\(\\) should return array\\{name\\: string, instance\\: string, database\\: string, prefix\\: string, cache_path\\: string|null, session_pool\\: array\\<string, mixed\\>\\} but returns non\\-empty\\-array\\<string, mixed\\>\\.$#"
           count: 1
           path: src/SpannerServiceProvider.php

--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -26,6 +26,7 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
+use LogicException;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -62,7 +63,7 @@ class SpannerServiceProvider extends ServiceProvider
      *      instance: string,
      *      database: string,
      *      prefix: string,
-     *      cache_path: string,
+     *      cache_path: string|null,
      *      session_pool: array<string, mixed>,
      * } $config
      * @return Connection

--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -26,7 +26,6 @@ use Illuminate\Database\DatabaseManager;
 use Illuminate\Queue\QueueManager;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\ServiceProvider;
-use LogicException;
 use Symfony\Component\Cache\Adapter\AdapterInterface;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 

--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -93,6 +93,10 @@ class SpannerServiceProvider extends ServiceProvider
      */
     protected function parseConfig(array $config, string $name): array
     {
+        if ($name === '_auth') {
+            throw new LogicException('Connection name "_auth" is reserved.');
+        }
+
         return $config + [
             'prefix' => '',
             'name' => $name,
@@ -108,7 +112,7 @@ class SpannerServiceProvider extends ServiceProvider
      */
     protected function createAuthCache(array $config): AdapterInterface
     {
-        return $this->getCacheAdapter('auth', $config['cache_path']);
+        return $this->getCacheAdapter('_auth', $config['cache_path']);
     }
 
     /**

--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -87,7 +87,7 @@ class SpannerServiceProvider extends ServiceProvider
      *       instance: string,
      *       database: string,
      *       prefix: string,
-     *       cache_path: string,
+     *       cache_path: string|null,
      *       session_pool: array<string, mixed>,
      *  } $config
      */
@@ -103,7 +103,7 @@ class SpannerServiceProvider extends ServiceProvider
     }
 
     /**
-     * @param array{ cache_path: string } $config
+     * @param array{ cache_path: string|null } $config
      * @return AdapterInterface
      */
     protected function createAuthCache(array $config): AdapterInterface
@@ -112,7 +112,7 @@ class SpannerServiceProvider extends ServiceProvider
     }
 
     /**
-     * @param array{ name: string, cache_path: string, session_pool: array<string, mixed> } $config
+     * @param array{ name: string, cache_path: string|null, session_pool: array<string, mixed> } $config
      * @return SessionPoolInterface
      */
     protected function createSessionPool(array $config): SessionPoolInterface


### PR DESCRIPTION
Coming from https://github.com/googleapis/google-cloud-php/issues/6703#issuecomment-1846328959

Auth does not lock the cache file, so it's possible for a race condition to occur.

Below is an example of how that may happen.

1. Process 1: Auth opens cache
2. Process 2: Session Pool opens cache
3. Process 2: Session Pool creates a session and saves (file is written)
4. Process 1: Auth writes to cache (file is overwritten and session created at 3. no longer exists in cache)

- [x] CHANGELOG

Must be backported to 6.0.
