### PR TITLE
add functionality to pass spanner types to insert/update

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -280,7 +280,7 @@ class Connection extends BaseConnection
     /**
      * @inheritDoc
      */
-    public function statement($query, $bindings = [], $types = []): bool
+    public function statement($query, $bindings = [], array $types = []): bool
     {
         // is SELECT query
         if (0 === stripos(ltrim($query), 'select')) {
@@ -298,19 +298,26 @@ class Connection extends BaseConnection
         return $this->runDdlBatch([$query]) !== null;
     }
 
-    public function insert($query, $bindings = [], $types = [])
+    /**
+     * @inheritDoc
+     */
+    public function insert($query, $bindings = [], array $types = []): bool
     {
         return $this->statement($query, $bindings, $types);
     }
 
-    public function update($query, $bindings = [], $types = [])
-    {
-        return $this->affectingStatement($query, $bindings, $types);
-    }
     /**
      * @inheritDoc
      */
-    public function affectingStatement($query, $bindings = [], $types = []): int
+    public function update($query, $bindings = [], array $types = []): int
+    {
+        return $this->affectingStatement($query, $bindings, $types);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function affectingStatement($query, $bindings = [], array $types = []): int
     {
         /** @var Closure(): int $runQueryCall */
         $runQueryCall = function () use ($query, $bindings, $types) {

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -39,8 +39,14 @@ class Model extends BaseModel
      */
     public $incrementing = false;
 
+    /**
+     * @var string[]
+     */
     protected $types = [];
 
+    /**
+     * @inheritDoc
+     */
     public function newModelQuery()
     {
         return parent::newModelQuery()->setTypes($this->types);

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -39,6 +39,13 @@ class Model extends BaseModel
      */
     public $incrementing = false;
 
+    protected $types = [];
+
+    public function newModelQuery()
+    {
+        return parent::newModelQuery()->setTypes($this->types);
+    }
+
     /**
      * @param BaseModel|Relation $query
      * @param mixed $value

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -17,6 +17,7 @@
 
 namespace Colopl\Spanner\Eloquent;
 
+use Colopl\Spanner\Query\Builder;
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
@@ -44,12 +45,16 @@ class Model extends BaseModel
      */
     protected $types = [];
 
-    /**
-     * @inheritDoc
-     */
-    public function newModelQuery()
+    public function newModelQuery(): Model
     {
-        return parent::newModelQuery()->setTypes($this->types);
+        return $this->newEloquentBuilder(
+            $this->newBaseQueryBuilder()->setTypes($this)
+        )->setModel($this);
+    }
+
+    protected function newBaseQueryBuilder(): Builder
+    {
+        return $this->getConnection()->query();
     }
 
     /**

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -45,17 +45,17 @@ class Model extends BaseModel
      */
     protected $types = [];
 
-    public function newModelQuery(): Builder|static
+    /** 
+     * @inheritDoc
+     */
+    public function newModelQuery()
     {
+        /** @var Builder */
+        $baseQueryBuilder = $this->newBaseQueryBuilder();
+
         return $this->newEloquentBuilder(
-            $this->newBaseQueryBuilder()->setTypes($this->types)
+            $baseQueryBuilder->setTypes($this->types)
         )->setModel($this);
-    }
-
-
-    protected function newBaseQueryBuilder(): Builder
-    {
-        return $this->getConnection()->query();
     }
 
     /**

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -45,12 +45,13 @@ class Model extends BaseModel
      */
     protected $types = [];
 
-    public function newModelQuery(): Model
+    public function newModelQuery(): Builder|static
     {
         return $this->newEloquentBuilder(
-            $this->newBaseQueryBuilder()->setTypes($this)
+            $this->newBaseQueryBuilder()->setTypes($this->types)
         )->setModel($this);
     }
+
 
     protected function newBaseQueryBuilder(): Builder
     {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -71,7 +71,7 @@ class Builder extends BaseBuilder
 
         $sql = $this->grammar->compileInsert($this, $values);
 
-        // Detect spanner types from values and greate a binding compatible array of types
+        // Detect spanner types from values and create a binding compatible array of types
         $types = [];
         $i = 0;
         foreach ($values as $key => $value) {
@@ -94,7 +94,7 @@ class Builder extends BaseBuilder
 
         $sql = $this->grammar->compileUpdate($this, $values);
 
-        // Detect spanner types from values and greate a binding compatible array of types
+        // Detect spanner types from values and create a binding compatible array of types
         $types = [];
         $i = 0;
         foreach ($values as $key => $value) {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -41,7 +41,7 @@ class Builder extends BaseBuilder
 
     /**
      * @param string[] $types
-     * @return self
+     * @return $this
      */
     public function setTypes($types)
     {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -107,7 +107,7 @@ class Builder extends BaseBuilder
     {
         if(!array_key_exists($key, $this->types)) return [];
         if($value == null) return [];
-        if (is_array($value) && empty($value)) return [];
+        if (is_array($value) && !count($value)) return [];
         if (is_string($value) && Parameterizer::hasLikeWildcard($sql, $value)) return [];
         return ["p$i", $this->types[$key]];
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -64,6 +64,7 @@ class Builder extends BaseBuilder
         if (! is_array(reset($values)))
             $values = [$values];
         else {
+            /** @var array $value */
             foreach ($values as $key => $value) {
                 ksort($value);
                 $values[$key] = $value;
@@ -100,14 +101,14 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @return string[]|false
+     * @return string[]
      */
     public function checkForType(int $i, string|int $key, mixed $value, string $sql = '')
     {
-        if(!array_key_exists($key, $this->types)) return false;
-        if($value == null) return false;
-        if (is_array($value) && empty($value)) return false;
-        if (is_string($value) && Parameterizer::hasLikeWildcard($sql, $value)) return false;
+        if(!array_key_exists($key, $this->types)) return [];
+        if($value == null) return [];
+        if (is_array($value) && empty($value)) return [];
+        if (is_string($value) && Parameterizer::hasLikeWildcard($sql, $value)) return [];
         return ["p$i", $this->types[$key]];
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -99,7 +99,10 @@ class Builder extends BaseBuilder
         ), $types);
     }
 
-    public function checkForType(int $i, string $key, mixed $value, string $sql = '')
+    /**
+     * @return string[]|false
+     */
+    public function checkForType(int $i, string|int $key, mixed $value, string $sql = '')
     {
         if(!array_key_exists($key, $this->types)) return false;
         if($value == null) return false;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -107,7 +107,11 @@ class Builder extends BaseBuilder
     {
         if(!array_key_exists($key, $this->types)) return [];
         if($value == null) return [];
-        if (is_array($value) && !count($value)) return [];
+
+        if (is_array($value)) {
+            /** @var array $value */
+            if(!count($value)) return [];
+        }
         if (is_string($value) && Parameterizer::hasLikeWildcard($sql, $value)) return [];
         return ["p$i", $this->types[$key]];
     }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -34,7 +34,15 @@ class Builder extends BaseBuilder
      */
     public $connection;
 
+    /**
+     * @var string[]
+     */
     protected $types = [];
+
+    /**
+     * @param string[] $types
+     * @return self
+     */
     public function setTypes($types)
     {
         $this->types = $types;
@@ -91,7 +99,7 @@ class Builder extends BaseBuilder
         ), $types);
     }
 
-    public function checkForType($i, $key, $value, $sql = '')
+    public function checkForType(int $i, string $key, mixed $value, string $sql = '')
     {
         if(!array_key_exists($key, $this->types)) return false;
         if($value == null) return false;

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -69,13 +69,15 @@ class Builder extends BaseBuilder
             }
         }
 
+        $sql = $this->grammar->compileInsert($this, $values);
+
         // Detect spanner types from values and greate a binding compatible array of types
         $types = [];
         $i = 0;
         foreach ($values as $key => $value) {
             /** @var array $value */
             foreach ($value as $k => $v) {
-                $type = $this->checkForType($i, $k, $v);
+                $type = $this->checkForType($i, $k, $v, $sql);
                 if(count($type)) $types[$type[0]] = $type[1];
                 $i++;
             }
@@ -83,7 +85,6 @@ class Builder extends BaseBuilder
 
         $this->applyBeforeQueryCallbacks();
 
-        $sql = $this->grammar->compileInsert($this, $values);
         return $this->connection->insert($sql, $this->cleanBindings(Arr::flatten($values, 1)), $types);
     }
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -121,6 +121,7 @@ class Builder extends BaseBuilder
             if(!count($value)) return [];
         }
         if (is_string($value) && Parameterizer::hasLikeWildcard($sql, $value)) return [];
+
         return ["p$i", $this->types[$key]];
     }
 

--- a/src/Query/Parameterizer.php
+++ b/src/Query/Parameterizer.php
@@ -72,7 +72,7 @@ class Parameterizer
      * @param string $value
      * @return bool
      */
-    private static function hasLikeWildcard(string $query, string $value)
+    public static function hasLikeWildcard(string $query, string $value)
     {
         return Str::contains(strtolower($query), 'like')
             && Str::contains($value, ['%', '_'])


### PR DESCRIPTION
This is a first attempt to resolve https://github.com/colopl/laravel-spanner/issues/149

The first step is to add a `$types` array to both Models and Builders, and to automatically inject a Models types array into every new Builder instance for that model.

The next step is overriding the base update/insert methods of the Builder, to loop through each value being passed in, and using a function `checkForType()` that attempts to apply the same conventions as the Parameterizer class, to generate an array of bound types eg `['p2' => Database::TYPE, ...]`.

The final step is adding an additional optional `$types = []` argument to Connection `update` / `insert` / `statement` / `affectingStatement` methods, so that it can be passed to the `$transaction->executeUpdate()` as an additional `types` argument alongside `parameters`

I am still not super familiar with how all the internals work here, likely there are several improvements that could be made, but hopefully this is a good jumping off point