### PR TITLE
query grammer compileLock - ignore

### DIFF
--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -43,7 +43,7 @@ class Grammar extends BaseGrammar
      */
     protected function compileLock(Builder $query, $value)
     {
-        $this->markAsNotSupported('explicit locking');
+        return '';
     }
 
     /**

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -792,32 +792,26 @@ class BuilderTest extends TestCase
 
     public function test_lock(): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cloud Spanner does not support explicit locking');
-
         $conn = $this->getDefaultConnection();
         $qb = $conn->table(self::TABLE_NAME_USER);
-        $qb->lock()->get();
+        $sql = $qb->lock()->toRawSql();
+        $this->assertSame('select * from `User`', $sql);
     }
 
     public function test_lockForUpdate(): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cloud Spanner does not support explicit locking');
-
         $conn = $this->getDefaultConnection();
         $qb = $conn->table(self::TABLE_NAME_USER);
-        $qb->lockForUpdate()->get();
+        $sql = $qb->lockForUpdate()->toRawSql();
+        $this->assertSame('select * from `User`', $sql);
     }
 
     public function test_sharedLock(): void
     {
-        $this->expectException(BadMethodCallException::class);
-        $this->expectExceptionMessage('Cloud Spanner does not support explicit locking');
-
         $conn = $this->getDefaultConnection();
         $qb = $conn->table(self::TABLE_NAME_USER);
-        $qb->sharedLock()->get();
+        $sql = $qb->sharedLock()->toRawSql();
+        $this->assertSame('select * from `User`', $sql);
     }
 
     public function test_toRawSql(): void


### PR DESCRIPTION
While its true spanner doesnt support explicit locking, I think the compileLock method should not throw an exception. It may be better to log a warning perhaps, but since spanner has complex lock handling and consistency, just gracefully allowing the lock to generate no additional code seems acceptable.

When using spanner with other frameworks (Laravel Nova in this case), it is necessary to ignore this.

Also if you look at: 
https://github.com/laravel/framework/blob/7907bfb50165b3951403e2d9882b4f8e0ee26b9e/src/Illuminate/Database/Query/Grammars/SQLiteGrammar.php#L29

and:
https://github.com/laravel/framework/blob/7907bfb50165b3951403e2d9882b4f8e0ee26b9e/src/Illuminate/Database/Query/Grammars/SqlServerGrammar.php#L340

You will see both of those return empty strings - I think graceful failure here is the much better approach