### PR TITLE
Add/alter columns should be separate statements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ Added
 Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)
 
+Fixed
+- `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements
+
 # v6.1.1 (2023-12-11)
 
 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)
 
 Fixed
-- `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements
+- `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)
 
 # v6.1.1 (2023-12-11)
 

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -161,13 +161,14 @@ class Grammar extends BaseGrammar
      *
      * @param  Blueprint  $blueprint
      * @param  Fluent<string, mixed> $command
-     * @return string
+     * @return string[]
      */
     public function compileDropColumn(Blueprint $blueprint, Fluent $command)
     {
-        $columns = $this->prefixArray('drop column', $this->wrapArray($command->columns));
-
-        return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
+        return $this->prefixArray(
+            'alter table '.$this->wrapTable($blueprint).' drop column',
+            $this->wrapArray($command->columns)
+        );
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -134,9 +134,10 @@ class Grammar extends BaseGrammar
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
     {
-        $columns = $this->prefixArray('add column', $this->getColumns($blueprint));
-
-        return 'alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns);
+        return $this->prefixArray(
+            'alter table '.$this->wrapTable($blueprint).' add column',
+            $this->getColumns($blueprint)
+        );
     }
 
     /**
@@ -149,9 +150,10 @@ class Grammar extends BaseGrammar
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-        $columns = $this->prefixArray('alter column', $this->getChangedColumns($blueprint));
-
-        return ['alter table '.$this->wrapTable($blueprint).' '.implode(', ', $columns)];
+       return $this->prefixArray(
+            'alter table '.$this->wrapTable($blueprint).' alter column',
+            $this->getChangedColumns($blueprint)
+        );
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -130,7 +130,7 @@ class Grammar extends BaseGrammar
      *
      * @param  Blueprint  $blueprint
      * @param  Fluent<string, mixed> $command
-     * @return string
+     * @return string[]
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
     {

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -108,12 +108,15 @@ class BlueprintTest extends TestCase
 
         $blueprint = new Blueprint('Test3', function (Blueprint $table) {
             $table->string('description', 255);
+            $table->integer('value');
         });
 
         $queries = $blueprint->toSql($conn, new Grammar());
-        $this->assertEquals(
+        $this->assertEquals([
             'alter table `Test3` add column `description` string(255) not null',
-            $queries[0]
+            'alter table `Test3` add column `value` int64 not null'
+            ],
+            $queries
         );
     }
 
@@ -123,12 +126,15 @@ class BlueprintTest extends TestCase
 
         $blueprint = new Blueprint('Test3', function (Blueprint $table) {
             $table->string('description', 512)->change();
+            $table->float('value')->change();
         });
 
         $queries = $blueprint->toSql($conn, new Grammar());
-        $this->assertEquals(
+        $this->assertEquals([
             'alter table `Test3` alter column `description` string(512) not null',
-            $queries[0]
+            'alter table `Test3` alter column `value` float64 not null',
+            ],
+            $queries
         );
     }
 


### PR DESCRIPTION
In Google Cloud Spanner, you cannot add or alter multiple columns in a single DML statement. Instead, you need to execute separate ALTER TABLE statements for each column you want to add or modify.

The current implementation make a single statement 
```sql
alter table `table` add column `column_one` string(max), add column `column_two` string(max);
```

This fix makes the correct statements
```sql
alter table `table` add column `column_one` string(max);
alter table `table` add column `column_two` string(max);
```

