### PR TITLE
fix: fixed an error when rolling back a transaction that did not execute begin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Changed
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)
 
+# v6.1.2 (2024-01-xx)
+
+Fixed
+- Fixed an error when rolling back a transaction that did not execute begin (#166)
+
 # v6.1.1 (2023-12-11)
 
 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Changed
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)
 
-# v6.1.2 (2024-01-xx)
+# v6.1.2 (2024-01-16)
 
 Fixed
 - Fixed an error when rolling back a transaction that did not execute begin (#166)

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -168,7 +168,7 @@ trait ManagesTransactions
 
         if ($this->currentTransaction !== null) {
             try {
-                if ($this->currentTransaction->state() === Transaction::STATE_ACTIVE) {
+                if ($this->currentTransaction->state() === Transaction::STATE_ACTIVE && $this->currentTransaction->id() !== null) {
                     $this->currentTransaction->rollBack();
                 }
             } finally {

--- a/tests/SessionNotFoundTest.php
+++ b/tests/SessionNotFoundTest.php
@@ -160,12 +160,12 @@ class SessionNotFoundTest extends TestCase
         $passes = 0;
 
         $conn->transaction(function () use ($conn, &$passes) {
-            $cursor = $conn->cursor('SELECT 12345');
-
             if ($passes === 0) {
                 $this->deleteSession($conn);
                 $passes++;
             }
+
+            $cursor = $conn->cursor('SELECT 12345');
 
             $this->assertEquals([12345], $cursor->current());
 


### PR DESCRIPTION
Fix: #165 

Several features and tests were broken due to the `google/cloud-spanner v1.68.0` release.

* An exception is thrown if rollback is performed without any query call in the transaction.
* Tests that depend on the query execution order called from the `cursor()` method fail.

## Checklist

- [x] CHANGELOG

## Reference

* https://github.com/googleapis/google-cloud-php-spanner/releases/tag/v1.68.0
