### PR TITLE
fix: Connection::runDdlBatch should allow empty

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ Changed
 
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)
-- `Connection::runDdlBatch()` with empty statement now return an empty array instead of throwing an error (#)
+- `Connection::runDdlBatch()` with empty statement now return an empty array instead of throwing an error (#169)
 
 # v6.1.2 (2024-01-16)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Changed
 
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)
+- `Connection::runDdlBatch()` with empty statement now return an empty array instead of throwing an error (#)
 
 # v6.1.2 (2024-01-16)
 

--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -58,6 +58,10 @@ trait ManagesDataDefinitions
      */
     public function runDdlBatch(array $statements): mixed
     {
+        if (count($statements) === 0) {
+            return [];
+        }
+
         $start = microtime(true);
 
         $result = $this->waitForOperation(

--- a/tests/Concerns/ManagesDataDefinitionsTest.php
+++ b/tests/Concerns/ManagesDataDefinitionsTest.php
@@ -42,6 +42,19 @@ class ManagesDataDefinitionsTest extends TestCase
         Event::assertDispatchedTimes(QueryExecuted::class, 1);
     }
 
+    public function test_runDdlBatch_with_empty_statement(): void
+    {
+        $events = Event::fake([QueryExecuted::class]);
+        $conn = $this->getDefaultConnection();
+        $conn->setEventDispatcher($events);
+        $conn->enableQueryLog();
+        $result = $conn->runDdlBatch([]);
+
+        $this->assertSame([], $result);
+        $this->assertCount(0, $conn->getQueryLog());
+        Event::assertNotDispatched(QueryExecuted::class);
+    }
+
     public function test_createDatabase_with_statements(): void
     {
         $events = Event::fake([QueryExecuted::class]);


### PR DESCRIPTION
Different approach to achieve the same result for https://github.com/colopl/laravel-spanner/pull/164.