### PR TITLE
feat: do primary key check on server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v6.2.0 (Not Released Yet)
+# v7.0.0 (Not Released Yet)
 
 Added
 - `json` `mediumText` `longText` `char` support for `Schema\Builder` (#155) (#158)
@@ -10,6 +10,7 @@ Added
 Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)
 - `Schema\Builder::getIndexListing()` `Schema\Grammar::compileIndexListing()` converted to `getIndexes()` and `compileIndexes()` to align with standard Laravel methods (#161)
+- Missing primary key will no longer be checked and will be checked on the server side instead (#177)
 
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -399,7 +399,7 @@ class Grammar extends BaseGrammar
         if (! is_null($primary = $this->getCommandByName($blueprint, 'primary'))) {
             return "primary key ({$this->columnize($primary->columns)})";
         }
-        throw new LogicException('Cloud Spanner require a primary key!');
+        return '';
     }
 
     /**

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -210,18 +210,6 @@ class BlueprintTest extends TestCase
         );
     }
 
-    public function test_no_primaryKey(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Cloud Spanner require a primary key!');
-
-        $blueprint = new Blueprint('test', function (Blueprint $table) {
-            $table->create();
-            $table->uuid('id');
-        });
-        $blueprint->toSql($this->getDefaultConnection(), new Grammar());
-    }
-
     public function testCompositePrimaryKey(): void
     {
         $conn = $this->getDefaultConnection();

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -210,19 +210,6 @@ class BlueprintTest extends TestCase
         ], $statements);
     }
 
-    public function test_no_primaryKey(): void
-    {
-        $this->expectException(LogicException::class);
-        $this->expectExceptionMessage('Cloud Spanner require a primary key!');
-
-        $tableName = $this->generateTableName();
-        $blueprint = new Blueprint($tableName, function (Blueprint $table) {
-            $table->create();
-            $table->uuid('id');
-        });
-        $blueprint->toSql($this->getDefaultConnection(), new Grammar());
-    }
-
     public function test_composite_primary_key(): void
     {
         $conn = $this->getDefaultConnection();


### PR DESCRIPTION
There is no need to do it on the client side. Server will throw a more precise error anyway.

Before:
```
LogicException: Cloud Spanner require a primary key!
```

After: 
```
Google\Cloud\Core\Exception\BadRequestException: {
    "message": "Error parsing Spanner DDL statement: create table `Temp_20240126_054222_000` (`id` string(36) not null)  : Syntax error on line 1, column 67: Expecting 'PRIMARY' but found 'EOF'",
    "code": 3,
    "status": "INVALID_ARGUMENT",
    "details": [
        {
            "@type": "grpc-status-details-bin",
            "data": "<Unknown Binary Data>"
        }
    ]
}
```