### PR TITLE
feat: allow default transaction attempts to be changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Added
 - Support for inserting and selecting array of DateTime/Numeric objects (#168)
 - Allow pretending for DDL statements (#170) 
 - Allow `spanner_emulator.disable_query_null_filtered_index_check` to be set (#180)
-- Allow default max transaction attempts to be changed (#)
+- Allow default max transaction attempts to be changed (#179)
 
 Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)
@@ -16,7 +16,7 @@ Changed
 - `Connection::runDdl()` and `Connection::runDdls()` has been removed. Use `Connection::runDdlBatch()` instead. (#178)
 - Trait `ManagesStaleReads` has been removed (which contained `cursorWithTimestampBound()` and `selectWithTimestampBound()`. Use `selectWithOptions()` instead). (#178)
 - `Blueprint::interleave()` and `IndexDefinition::interleave()` now throw an error instead of a deprecation. (#178)
-- `Connection::transaction()`'s `$attempts` argument's default value was changed from 10 to -1 (which is a magic number for default value which is 11) (#)
+- `Connection::transaction()`'s `$attempts` argument's default value was changed from 10 to -1 (which is a magic number for default value which is 11) (#179)
 
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Added
 - Support for inserting and selecting array of DateTime/Numeric objects (#168)
 - Allow pretending for DDL statements (#170) 
 - Allow `spanner_emulator.disable_query_null_filtered_index_check` to be set (#180)
+- Allow default max transaction attempts to be changed (#)
 
 Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)
@@ -15,6 +16,7 @@ Changed
 - `Connection::runDdl()` and `Connection::runDdls()` has been removed. Use `Connection::runDdlBatch()` instead. (#178)
 - Trait `ManagesStaleReads` has been removed (which contained `cursorWithTimestampBound()` and `selectWithTimestampBound()`. Use `selectWithOptions()` instead). (#178)
 - `Blueprint::interleave()` and `IndexDefinition::interleave()` now throw an error instead of a deprecation. (#178)
+- `Connection::transaction()`'s `$attempts` argument's default value was changed from 10 to -1 (which is a magic number for default value which is 11) (#)
 
 Fixed
 - `Schema\Grammar::compileAdd()` `Schema\Grammar::compileChange()` `Schema\Grammar::compileChange()` now create separate statements (#159)

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -50,7 +50,7 @@ trait ManagesTransactions
         // -1 is used as a magic number to indicate the default value defined in Database::MAX_RETRIES (+1)
         // So, we need to resolve the actual value here.
         if ($attempts === -1) {
-            $attempts = $this->getMaxTransactionAttempts();
+            $attempts = $this->getDefaultMaxTransactionAttempts();
         }
 
         // Since Cloud Spanner does not support nested transactions,
@@ -237,7 +237,7 @@ trait ManagesTransactions
     /**
      * @return int
      */
-    public function getMaxTransactionAttempts(): int
+    public function getDefaultMaxTransactionAttempts(): int
     {
         return $this->maxAttempts ??= (Database::MAX_RETRIES + 1);
     }
@@ -246,7 +246,7 @@ trait ManagesTransactions
      * @param int $attempts
      * @return $this
      */
-    public function setMaxTransactionAttempts(int $attempts): static
+    public function setDefaultMaxTransactionAttempts(int $attempts): static
     {
         $this->maxAttempts = $attempts;
         return $this;

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -528,66 +528,6 @@ class ConnectionTest extends TestCase
         $this->assertEquals(TransactionCommitted::class, $receivedEventClasses[2]);
     }
 
-    public function test_connection_transaction_reset_on_exceptions(): void
-    {
-        $conn = $this->getDefaultConnection();
-
-        try {
-            $conn->transaction(function (Connection $conn) {
-                self::assertTrue($conn->inTransaction());
-                self::assertNotNull($conn->getCurrentTransaction());
-                self::assertSame(1, $conn->transactionLevel());
-                throw new NotFoundException('NG');
-            });
-        } catch(NotFoundException) {
-            // do nothing.
-        }
-
-        self::assertfalse($conn->inTransaction());
-        self::assertNull($conn->getCurrentTransaction());
-        self::assertSame(0, $conn->transactionLevel());
-    }
-
-    public function test_connection_transaction_reset_on_rollback_exceptions(): void
-    {
-        $base = $this->getDefaultConnection();
-
-        $conn = new class($base) extends Connection {
-            public function __construct(Connection $base)
-            {
-                parent::__construct(
-                    $base->instanceId,
-                    $base->database,
-                    $base->tablePrefix,
-                    $base->config,
-                    $base->authCache,
-                    $base->sessionPool,
-                );
-            }
-
-            protected function performRollBack($toLevel): void
-            {
-                $this->currentTransaction = null;
-                throw new AbortedException('NG');
-            }
-        };
-
-        try {
-            $conn->transaction(function (Connection $conn): mixed {
-                self::assertTrue($conn->inTransaction());
-                self::assertNotNull($conn->getCurrentTransaction());
-                self::assertSame(1, $conn->transactionLevel());
-                throw new RuntimeException('Trigger rollback');
-            });
-        } catch(AbortedException) {
-            // do nothing.
-        }
-
-        self::assertfalse($conn->inTransaction());
-        self::assertNull($conn->getCurrentTransaction());
-        self::assertSame(0, $conn->transactionLevel());
-    }
-
     public function test_escape(): void
     {
         $conn = $this->getDefaultConnection();

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -19,7 +19,6 @@ namespace Colopl\Spanner\Tests;
 
 use Exception;
 use Google\Cloud\Core\Exception\AbortedException;
-use Google\Cloud\Spanner\Database;
 use Google\Cloud\Spanner\Transaction;
 use Colopl\Spanner\Connection;
 use Google\Cloud\Spanner\TransactionalReadInterface;

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -19,6 +19,7 @@ namespace Colopl\Spanner\Tests;
 
 use Exception;
 use Google\Cloud\Core\Exception\AbortedException;
+use Google\Cloud\Core\Exception\NotFoundException;
 use Google\Cloud\Spanner\Transaction;
 use Colopl\Spanner\Connection;
 use Google\Cloud\Spanner\TransactionalReadInterface;
@@ -304,20 +305,123 @@ class TransactionTest extends TestCase
         Event::assertDispatchedTimes(TransactionRolledBack::class, 1);
     }
 
-    public function testAbortedException(): void
+    public function test_default_attempts(): void
     {
-        Event::fake();
-        $retries = 3;
+        $events = Event::fake();
         $conn = $this->getDefaultConnection();
+        $aborted = false;
+        $attempts = 11;
         try {
-            $conn->transaction(fn() => throw new AbortedException('abort'), $retries);
+            $conn->transaction(fn() => throw new AbortedException('abort'));
         } catch (AbortedException) {
-
+            $aborted = true;
         }
 
-        Event::assertDispatchedTimes(TransactionBeginning::class, $retries);
-        Event::assertDispatchedTimes(TransactionCommitting::class, 0);
-        Event::assertDispatchedTimes(TransactionCommitted::class, 0);
-        Event::assertDispatchedTimes(TransactionRolledBack::class, $retries);
+        $this->assertTrue($aborted);
+        $events->assertDispatchedTimes(TransactionBeginning::class, $attempts);
+        $events->assertDispatchedTimes(TransactionCommitting::class, 0);
+        $events->assertDispatchedTimes(TransactionCommitted::class, 0);
+        $events->assertDispatchedTimes(TransactionRolledBack::class, $attempts);
+        $this->assertSame($attempts, $conn->getDefaultMaxTransactionAttempts());
+    }
+
+    public function test_user_defined_attempts(): void
+    {
+        $events = Event::fake();
+        $conn = $this->getDefaultConnection();
+        $aborted = false;
+        $attempts = 3;
+        try {
+            $conn->transaction(fn() => throw new AbortedException('abort'), $attempts);
+        } catch (AbortedException) {
+            $aborted = true;
+        }
+
+        $this->assertTrue($aborted);
+        $events->assertDispatchedTimes(TransactionBeginning::class, $attempts);
+        $events->assertDispatchedTimes(TransactionCommitting::class, 0);
+        $events->assertDispatchedTimes(TransactionCommitted::class, 0);
+        $events->assertDispatchedTimes(TransactionRolledBack::class, $attempts);
+        $this->assertSame(11, $conn->getDefaultMaxTransactionAttempts());
+    }
+
+    public function test_setDefaultMaxTransactionAttempts(): void
+    {
+        $events = Event::fake();
+        $attempts = 2;
+        $conn = $this->getDefaultConnection();
+        $conn->setDefaultMaxTransactionAttempts($attempts);
+        $aborted = false;
+        try {
+            $conn->transaction(fn() => throw new AbortedException('abort'));
+        } catch (AbortedException) {
+            $aborted = true;
+        }
+
+        $this->assertTrue($aborted);
+        $this->assertSame($attempts, $conn->getDefaultMaxTransactionAttempts());
+        $events->assertDispatchedTimes(TransactionBeginning::class, $attempts);
+        $events->assertDispatchedTimes(TransactionCommitting::class, 0);
+        $events->assertDispatchedTimes(TransactionCommitted::class, 0);
+        $events->assertDispatchedTimes(TransactionRolledBack::class, $attempts);
+    }
+
+    public function test_reset_on_exceptions(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $exceptionThrown = false;
+        try {
+            $conn->transaction(function (Connection $conn) {
+                $this->assertSame(1, $conn->transactionLevel());
+                throw new NotFoundException('NG');
+            });
+        } catch(NotFoundException) {
+            $exceptionThrown = true;
+        }
+
+        $this->assertTrue($exceptionThrown);
+        $this->assertfalse($conn->inTransaction());
+        $this->assertSame(0, $conn->transactionLevel());
+    }
+
+    public function test_reset_on_rollback_exceptions(): void
+    {
+        $base = $this->getDefaultConnection();
+        $aborted = false;
+
+        $conn = new class($base) extends Connection {
+            public function __construct(Connection $base)
+            {
+                parent::__construct(
+                    $base->instanceId,
+                    $base->database,
+                    $base->tablePrefix,
+                    $base->config,
+                    $base->authCache,
+                    $base->sessionPool,
+                );
+            }
+
+            protected function performRollBack($toLevel): void
+            {
+                $this->currentTransaction = null;
+                throw new AbortedException('NG');
+            }
+        };
+
+        try {
+            $conn->transaction(function (Connection $conn): mixed {
+                $this->assertTrue($conn->inTransaction());
+                $this->assertSame(1, $conn->transactionLevel());
+                throw new RuntimeException('Trigger rollback');
+            });
+        } catch(AbortedException) {
+            // do nothing.
+            $aborted = true;
+        }
+
+        $this->assertTrue($aborted);
+        $this->assertFalse($conn->inTransaction());
+        $this->assertSame(0, $conn->transactionLevel());
     }
 }


### PR DESCRIPTION
Warning: `Connection::transaction()`'s `$attempts` argument's default value was changed from 10 to -1 (which is a magic number for default value which is 11). 

Default is set to 11 because Spanner library sets default retries to 10 and we add 1 to that since laravel defines amount of attempts not amount of retries.
