### PR TITLE
feat: allow spanner_emulator.disable_query_null_filtered_index_check to be set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Added
 - `Schema\Builder::dropAllTables` works properly, dropping foreign keys, indexes, then tables in order of interleaving (#161)
 - Support for inserting and selecting array of DateTime/Numeric objects (#168)
 - Allow pretending for DDL statements (#170) 
-- Allow spanner_emulator.disable_query_null_filtered_index_check to be set (#180)
+- Allow `spanner_emulator.disable_query_null_filtered_index_check` to be set (#180)
 
 Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Added
 - `Schema\Builder::dropAllTables` works properly, dropping foreign keys, indexes, then tables in order of interleaving (#161)
 - Support for inserting and selecting array of DateTime/Numeric objects (#168)
 - Allow pretending for DDL statements (#170) 
+- Allow spanner_emulator.disable_query_null_filtered_index_check to be set (#180)
 
 Changed
 - `Query\Builder::lock()` no longer throw an error and will be ignored instead (#156)

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -12,6 +12,9 @@ parameters:
           path: src/Concerns/ManagesPartitionedDml.php
         - message: '#^Unable to resolve the template type TKey in call to function collect$#'
           path: src/Concerns/ManagesSessionPool.php
+        - message: "#^Strict comparison using \\=\\=\\= between Illuminate\\\\Database\\\\Query\\\\IndexHint and null will always evaluate to false\\.$#"
+          count: 1
+          path: src/Query/Builder.php
         - message: '#^Parameter \#1 \$pdo of method Illuminate\\Database\\Connection::__construct\(\) expects Closure|PDO, null given\.$#'
           path: src/Connection.php
         - message: '#^Parameter \#1 \$start of method Illuminate\\Database\\Connection::getElapsedTime\(\) expects int, float given\.$#'

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -21,6 +21,8 @@ use Colopl\Spanner\Connection;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Arr;
+use LogicException;
+use Override;
 
 class Builder extends BaseBuilder
 {
@@ -146,5 +148,30 @@ class Builder extends BaseBuilder
         }
 
         return $this->connection->selectWithOptions($sql, $bindings, $options); 
+    }
+
+    /**
+     * @param string $index
+     * @return $this
+     */
+    public function forceIndex($index): static
+    {
+        $this->indexHint = new IndexHint('force', $index);
+
+        return $this;
+    }
+
+    public function disableEmulatorNullFilterIndexCheck(): static
+    {
+        $indexHint = $this->indexHint;
+
+        if ($indexHint === null) {
+            throw new LogicException('Force index must be set before disabling null filter index check');
+        }
+
+        assert($indexHint instanceof IndexHint);
+        $indexHint->disableEmulatorNullFilteredIndexCheck = true;
+
+        return $this;
     }
 }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -164,7 +164,7 @@ class Builder extends BaseBuilder
     /**
      * @return $this
      */
-    public function disableEmulatorNullFilterIndexCheck(): static
+    public function disableEmulatorNullFilteredIndexCheck(): static
     {
         $indexHint = $this->indexHint;
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -22,7 +22,6 @@ use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Arr;
 use LogicException;
-use Override;
 
 class Builder extends BaseBuilder
 {

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -161,6 +161,9 @@ class Builder extends BaseBuilder
         return $this;
     }
 
+    /**
+     * @return $this
+     */
     public function disableEmulatorNullFilterIndexCheck(): static
     {
         $indexHint = $this->indexHint;

--- a/src/Query/IndexHint.php
+++ b/src/Query/IndexHint.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Colopl\Spanner\Query;
+
+use Illuminate\Database\Query\IndexHint as BaseIndexHint;
+
+class IndexHint extends BaseIndexHint
+{
+    public bool $disableEmulatorNullFilteredIndexCheck = false;
+}

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -443,7 +443,7 @@ class BuilderTest extends TestCase
 
         $qb = $conn->table($tableName)
             ->forceIndex('test_index_name')
-            ->disableEmulatorNullFilterIndexCheck();
+            ->disableEmulatorNullFilteredIndexCheck();
 
         $hint = '@{FORCE_INDEX=test_index_name,spanner_emulator.disable_query_null_filtered_index_check=true}';
         $this->assertSame("select * from `{$tableName}` {$hint}", $qb->toSql());
@@ -456,7 +456,7 @@ class BuilderTest extends TestCase
         $this->expectException(LogicException::class);
 
         $conn = $this->getDefaultConnection();
-        $conn->table('Test')->disableEmulatorNullFilterIndexCheck();
+        $conn->table('Test')->disableEmulatorNullFilteredIndexCheck();
     }
 
     public function test_useIndex(): void

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -28,6 +28,8 @@ use Illuminate\Support\Str;
 use Illuminate\Database\QueryException;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
+use LogicException;
+
 use const Grpc\STATUS_ALREADY_EXISTS;
 
 class BuilderTest extends TestCase
@@ -251,7 +253,7 @@ class BuilderTest extends TestCase
         for ($i = 0; $i < 100; $i++) {
             $insertValues[] = [
                 'userId' => $this->generateUuid(),
-                'name' => 'test'.$i,
+                'name' => 'test' . $i,
             ];
         }
         $qb->insert($insertValues);
@@ -400,7 +402,7 @@ class BuilderTest extends TestCase
         $testDataCount = 100;
         $insertValues = [];
         for ($i = 0; $i < $testDataCount; $i++) {
-            $insertValues[] = ['userId' => $this->generateUuid(), 'name' => 'test'.$i];
+            $insertValues[] = ['userId' => $this->generateUuid(), 'name' => 'test' . $i];
         }
         $qb->insert($insertValues);
 
@@ -446,6 +448,15 @@ class BuilderTest extends TestCase
         $hint = '@{FORCE_INDEX=test_index_name,spanner_emulator.disable_query_null_filtered_index_check=true}';
         $this->assertSame("select * from `{$tableName}` {$hint}", $qb->toSql());
         $this->assertSame([], $qb->get()->all());
+    }
+
+    public function test_disableEmulatorNullFilteredIndexCheck_without_calling_force_index(): void
+    {
+        $this->expectExceptionMessage('Force index must be set before disabling null filter index check');
+        $this->expectException(LogicException::class);
+
+        $conn = $this->getDefaultConnection();
+        $conn->table('Test')->disableEmulatorNullFilterIndexCheck();
     }
 
     public function test_useIndex(): void


### PR DESCRIPTION
An [error is thrown](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/blob/123682157cbf8fa5cb13f0d7edb9b66070bb4a11/common/errors.cc#L2539-L2554) when the following condition is met.

- Spanner Emulator is used
- index is defined as `NULL_FILTERED`
- FORCE_INDEX statement hint is set on the query

This allows it to be bypassed by calling `Builder::disableEmulatorNullFilterIndexCheck()`.