### PR TITLE
fix: prepareBinding should not have changed return type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v7.0.1 (2024-02-21)
+# v7.0.1 (2024-02-22)
 
 Fixed
 - `Connection::prepareBinding()` should not have changed return type (#188)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v7.0.1 (2024-02-21)
+
+Fixed
+- `Connection::prepareBinding()` should not have changed return type (#188)
+
 # v7.0.0 (2024-02-21)
 
 Added

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -418,12 +418,12 @@ class Connection extends BaseConnection
         }
 
         // We need to transform all instances of DateTimeInterface into the actual
-        // date string. Each query grammar maintains its own date string format
+        // date string. Each query grammar maintains its own date string format,
         // so we'll just ask the grammar for the format to get from the date.
         if ($value instanceof DateTimeInterface) {
-            return new Timestamp($value);
+            return $value->format($grammar->getDateFormat());
         }
-
+        
         if (is_array($value)) {
             $arr = [];
             foreach ($value as $k => $v) {

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -967,6 +967,9 @@ class BuilderTest extends TestCase
 
         $sql = $conn->table($table)->where('s', "t\"e\"s\nt")->toRawSql();
         $this->assertSame("select * from `RawSqlTest` where `s` = r\"\"\"t\\\"e\\\"s\nt\"\"\"", $sql, 'newline with escaped quote');
+
+        $sql = $conn->table($table)->where('s', new Carbon('2024-02-21 00:00:00'))->toRawSql();
+        $this->assertSame('select * from `RawSqlTest` where `s` = "2024-02-21T00:00:00.000000+00:00"', $sql, 'Carbon');
     }
 
     public function test_dataBoost_enabled(): void


### PR DESCRIPTION
Reverts part that changed the return type in https://github.com/colopl/laravel-spanner/pull/168.

Broke toRawSql formatting output for DateTime objects.