### PR TITLE
Make default morphs type UUID

### DIFF
--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -34,6 +34,13 @@ class Builder extends BaseBuilder
     public static $defaultBinaryLength = 255;
 
     /**
+     * The default relationship morph key type.
+     *
+     * @var string
+     */
+    public static $defaultMorphKeyType = 'uuid';
+
+    /**
      * @deprecated Will be removed in a future Laravel version.
      *
      * @return list<array{ name: string, type: string }>


### PR DESCRIPTION
Since the usual behaviour of spanner is UUID primary keys, and the id/increments columns now create UUID columns by default, the default morphs type should be UUID 

