### PR TITLE
dropAll() return immediately if no tables found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# v7.0.1? (?)
+# v7.1.0 (Not released yet)
 
 Changed
 - `Schema\Builder::dropAllTables` returns immediately if no tables exist (#193)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # v7.0.1? (?)
 
 Changed
-- `Schema\Builder::dropAll()` returns immediately if no tables exist (#193)
+- `Schema\Builder::dropAllTables` returns immediately if no tables exist (#193)
 
 # v7.0.0 (2024-02-21)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v7.0.1? (?)
+
+Changed
+- `Schema\Builder::dropAll()` returns immediately if no tables exist (#193)
+
 # v7.0.0 (2024-02-21)
 
 Added

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -112,6 +112,11 @@ class Builder extends BaseBuilder
         /** @var Connection $connection */
         $connection = $this->connection;
         $tables = $this->getTables();
+
+        if(count($tables) === 0) {
+            return;
+        }
+        
         $sortedTables = [];
 
         // add parents counter

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -307,4 +307,18 @@ class BuilderTestLast extends TestCase
         $tables = $sb->getTables();
         $this->assertEmpty($tables);
     }
+
+    public function test_dropAllTablesEmpty(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $sb = $conn->getSchemaBuilder();
+
+        $tables = $sb->getTables();
+        $this->assertEmpty($tables);
+
+        $sb->dropAllTables();
+
+        $tables = $sb->getTables();
+        $this->assertEmpty($tables);
+    }
 }

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -312,6 +312,9 @@ class BuilderTestLast extends TestCase
     {
         $conn = $this->getDefaultConnection();
         $sb = $conn->getSchemaBuilder();
+
+         // All tables must be dropped before hand to ensure that this test will cover the "early return" case
+         // for when there are no tables.
         $sb->dropAllTables();
 
         $tables = $sb->getTables();

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -308,7 +308,7 @@ class BuilderTestLast extends TestCase
         $this->assertEmpty($tables);
     }
 
-    public function test_dropAllTablesEmpty(): void
+    public function test_dropAllTables_when_no_tables_exist(): void
     {
         $conn = $this->getDefaultConnection();
         $sb = $conn->getSchemaBuilder();

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -312,6 +312,7 @@ class BuilderTestLast extends TestCase
     {
         $conn = $this->getDefaultConnection();
         $sb = $conn->getSchemaBuilder();
+        $sb->dropAllTables();
 
         $tables = $sb->getTables();
         $this->assertEmpty($tables);


### PR DESCRIPTION
Small tweak to Schema Builder dropAll() - if no tables exists simply return immediately 

