### PR TITLE
Spanner migrate commands

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,3 +44,5 @@ parameters:
         - message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
           count: 1
           path: src/Connection.php
+        - message: '#^Cannot cast mixed to string\.$#'
+          path: src/Console/MigrateCommand.php

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -71,7 +71,7 @@ class MigrateCommand extends Command
                 $repository->createRepository();
             $migrator->runPending($migrations);
         });
-    
+
         foreach($results as $result) {
             $query = $result['query'];
             if(Str::startsWith($query, 'select')) continue;

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -14,13 +14,13 @@ class MigrateCommand extends Command
 {
     protected $signature = 'spanner:migrate {--seed}';
 
-    public function handle($fresh = false)
+    public function handle(bool $fresh = false):void
     {
         $connection = DB::connection();
 
         // check if we not in spanner mode
         if(!$connection instanceof Connection) {
-            $command = 'migrate' . $fresh ? ':fresh' : '';
+            $command = 'migrate' . ($fresh ? ':fresh' : '');
             $this->call($command, ['--seed' => $this->option('seed')]);
             return;
         }
@@ -28,8 +28,8 @@ class MigrateCommand extends Command
         // if running emulator, ensure instance exists
         if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
             $this->info('Checking Emulator Instance');
-            $spanner = new SpannerClient($connection->getConfig('client'));
-            $instanceName = $connection->getConfig('instance');
+            $spanner = new SpannerClient((array)$connection->getConfig('client'));
+            $instanceName = (string)$connection->getConfig('instance');
             if (! $spanner->instance($instanceName)->exists()) {
                 $config = $spanner->instanceConfiguration('emulator-config');
                 $spanner->createInstance($config, $instanceName)->pollUntilComplete();

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -97,7 +97,7 @@ class MigrateCommand extends Command
 
         if($this->option('seed'))
             $this->call('db:seed');
-        else
-            $this->info("Done");
+        
+        $this->info("Done");
     }
 }

--- a/src/Console/MigrateCommand.php
+++ b/src/Console/MigrateCommand.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+use Closure;
+use Colopl\Spanner\Connection;
+use Google\Cloud\Spanner\SpannerClient;
+use Illuminate\Console\Command;
+use Illuminate\Database\Migrations\Migrator;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+
+class MigrateCommand extends Command
+{
+    protected $signature = 'spanner:migrate {--seed}';
+
+    public function handle($fresh = false)
+    {
+        $connection = DB::connection();
+
+        // check if we not in spanner mode
+        if(!$connection instanceof Connection) {
+            $command = 'migrate' . $fresh ? ':fresh' : '';
+            $this->call($command, ['--seed' => $this->option('seed')]);
+            return;
+        }
+
+        // if running emulator, ensure instance exists
+        if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
+            $this->info('Checking Emulator Instance');
+            $spanner = new SpannerClient($connection->getConfig('client'));
+            $instanceName = $connection->getConfig('instance');
+            if (! $spanner->instance($instanceName)->exists()) {
+                $config = $spanner->instanceConfiguration('emulator-config');
+                $spanner->createInstance($config, $instanceName)->pollUntilComplete();
+                $this->info('Created Emulator Instance');
+            }
+        }
+
+        $this->info('Checking DB');
+        if(!$connection->databaseExists()) {
+            $this->info('Creating DB');
+            $connection->createDatabase();
+        }
+
+        if($fresh) {
+            $this->info('Dropping all tables');
+            $connection->getSchemaBuilder()->dropAllTables();
+        }
+
+        $this->info('Generating batch DDL');
+
+        /** @var Migrator */
+        $migrator = app('migrator');
+        $migrationPath = $this->laravel->databasePath().DIRECTORY_SEPARATOR.'migrations';
+        $migrations = $migrator->getMigrationFiles($migrationPath);
+        $repository = $migrator->getRepository();
+        $repositoryExists = $repository->repositoryExists();
+        $ran = $repositoryExists ? $repository->getRan() : [];
+        $getPending = Closure::bind(fn($files, $ran) => $this->pendingMigrations($files, $ran), $migrator, $migrator);
+        $migrations = $getPending($migrations, $ran);
+
+        foreach ($migrations as $path) {
+            $this->output->write(str_replace(base_path(), '', $path), true);
+        }
+
+        $ddl = [];
+        $dml = [];
+        $results = $connection->pretend(function() use ($migrator, $migrations, $repository, $repositoryExists) {
+            if(!$repositoryExists)
+                $repository->createRepository();
+            $migrator->runPending($migrations);
+        });
+    
+        foreach($results as $result) {
+            $query = $result['query'];
+            if(Str::startsWith($query, 'select')) continue;
+
+            if(Str::startsWith($query, ['update', 'insert'])) 
+                $dml[] = $result;
+            else
+                $ddl[] = $query;
+        }
+
+        if(count($ddl)) {
+            $this->info('Running batch DDL');
+            $connection->runDdlBatch($ddl);
+        } else
+            $this->info('Nothing to migrate');
+
+        if(count($dml)) {
+            $this->info('Running DML');
+            foreach ($dml as $d) {
+                $connection->statement($d['query'], $d['bindings']);
+            }
+        }
+
+        if($this->option('seed'))
+            $this->call('db:seed');
+        else
+            $this->info("Done");
+    }
+}

--- a/src/Console/MigrateFreshCommand.php
+++ b/src/Console/MigrateFreshCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Colopl\Spanner\Console;
+
+class MigrateFreshCommand extends MigrateCommand
+{
+    protected $signature = 'spanner:migrate:fresh {--seed}';
+
+    public function handle($fresh = true)
+    {
+        parent::handle(true);
+    }
+}

--- a/src/Console/MigrateFreshCommand.php
+++ b/src/Console/MigrateFreshCommand.php
@@ -6,7 +6,7 @@ class MigrateFreshCommand extends MigrateCommand
 {
     protected $signature = 'spanner:migrate:fresh {--seed}';
 
-    public function handle($fresh = true)
+    public function handle(bool $fresh = true):void
     {
         parent::handle(true);
     }

--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -18,6 +18,8 @@
 namespace Colopl\Spanner;
 
 use Colopl\Spanner\Console\CooldownCommand;
+use Colopl\Spanner\Console\MigrateCommand;
+use Colopl\Spanner\Console\MigrateFreshCommand;
 use Colopl\Spanner\Console\SessionsCommand;
 use Colopl\Spanner\Console\WarmupCommand;
 use Google\Cloud\Spanner\Session\CacheSessionPool;
@@ -48,6 +50,8 @@ class SpannerServiceProvider extends ServiceProvider
                 CooldownCommand::class,
                 SessionsCommand::class,
                 WarmupCommand::class,
+                MigrateCommand::class,
+                MigrateFreshCommand::class,
             ]);
         }
     }

--- a/tests/Console/MigrateCommandTest.php
+++ b/tests/Console/MigrateCommandTest.php
@@ -15,27 +15,19 @@
  * limitations under the License.
  */
 
-$conn = [
-    'driver' => 'spanner',
-    'instance' => getenv('DB_SPANNER_INSTANCE_ID'),
-    'database' => getenv('DB_SPANNER_DATABASE_ID'),
+namespace Console;
 
-    'client' => [
-        'projectId' => getenv('DB_SPANNER_PROJECT_ID'),
-        'requestTimeout' => 600,
-    ],
+use Colopl\Spanner\Tests\Console\TestCase;
 
-    'session_pool' => [
-        'minSessions' => 1,
-        'maxSessions' => 100,
-    ],
-];
-
-return [
-    'connections' => [
-        'main' => $conn,
-        'alternative' => ['database' => $conn['database'] . '-alt'] + $conn,
-    ],
-    'default' => 'main',
-    'migrations' => 'migrations',
-];
+class MigrateCommandTest extends TestCase
+{
+    public function test_no_args(): void
+    {
+        $this->artisan('spanner:migrate')
+            ->expectsOutputToContain("Checking DB")
+            ->expectsOutputToContain("Generating batch DDL")
+            ->doesntExpectOutputToContain("Dropping all tables")
+            ->assertSuccessful()
+            ->run();
+    }
+}

--- a/tests/Console/MigrateCommandTest.php
+++ b/tests/Console/MigrateCommandTest.php
@@ -18,6 +18,7 @@
 namespace Console;
 
 use Colopl\Spanner\Tests\Console\TestCase;
+use Colopl\Spanner\Tests\DatabaseSeeder;
 
 class MigrateCommandTest extends TestCase
 {
@@ -26,6 +27,23 @@ class MigrateCommandTest extends TestCase
         $this->artisan('spanner:migrate')
             ->expectsOutputToContain("Checking DB")
             ->expectsOutputToContain("Generating batch DDL")
+            ->expectsOutputToContain("Done")
+            ->doesntExpectOutputToContain("Dropping all tables")
+            ->doesntExpectOutputToContain("Seeding database")
+            ->assertSuccessful()
+            ->run();
+    }
+
+    public function test_with_seed(): void
+    {
+        if(!class_exists('DatabaseSeeder'))
+            class_alias(DatabaseSeeder::class, 'DatabaseSeeder');
+
+        $this->artisan('spanner:migrate', ['--seed' => true])
+            ->expectsOutputToContain("Checking DB")
+            ->expectsOutputToContain("Generating batch DDL")
+            ->expectsOutputToContain("Seeding database")
+            ->expectsOutputToContain("Done")
             ->doesntExpectOutputToContain("Dropping all tables")
             ->assertSuccessful()
             ->run();

--- a/tests/Console/MigrateCommandTestLast.php
+++ b/tests/Console/MigrateCommandTestLast.php
@@ -20,7 +20,7 @@ namespace Console;
 use Colopl\Spanner\Tests\Console\TestCase;
 use Colopl\Spanner\Tests\DatabaseSeeder;
 
-class MigrateCommandTest extends TestCase
+class MigrateCommandTestLast extends TestCase
 {
     public function test_no_args(): void
     {

--- a/tests/Console/MigrateFreshCommandTestLast.php
+++ b/tests/Console/MigrateFreshCommandTestLast.php
@@ -15,27 +15,19 @@
  * limitations under the License.
  */
 
-$conn = [
-    'driver' => 'spanner',
-    'instance' => getenv('DB_SPANNER_INSTANCE_ID'),
-    'database' => getenv('DB_SPANNER_DATABASE_ID'),
+namespace Console;
 
-    'client' => [
-        'projectId' => getenv('DB_SPANNER_PROJECT_ID'),
-        'requestTimeout' => 600,
-    ],
+use Colopl\Spanner\Tests\Console\TestCase;
 
-    'session_pool' => [
-        'minSessions' => 1,
-        'maxSessions' => 100,
-    ],
-];
-
-return [
-    'connections' => [
-        'main' => $conn,
-        'alternative' => ['database' => $conn['database'] . '-alt'] + $conn,
-    ],
-    'default' => 'main',
-    'migrations' => 'migrations',
-];
+class MigrateFreshCommandTestLast extends TestCase
+{
+    public function test_no_args(): void
+    {
+        $this->artisan('spanner:migrate:fresh')
+            ->expectsOutputToContain("Checking DB")
+            ->expectsOutputToContain("Generating batch DDL")
+            ->expectsOutputToContain("Dropping all tables")
+            ->assertSuccessful()
+            ->run();
+    }
+}

--- a/tests/Console/MigrateFreshCommandTestLast.php
+++ b/tests/Console/MigrateFreshCommandTestLast.php
@@ -18,6 +18,7 @@
 namespace Console;
 
 use Colopl\Spanner\Tests\Console\TestCase;
+use Colopl\Spanner\Tests\DatabaseSeeder;
 
 class MigrateFreshCommandTestLast extends TestCase
 {
@@ -25,8 +26,25 @@ class MigrateFreshCommandTestLast extends TestCase
     {
         $this->artisan('spanner:migrate:fresh')
             ->expectsOutputToContain("Checking DB")
-            ->expectsOutputToContain("Generating batch DDL")
             ->expectsOutputToContain("Dropping all tables")
+            ->expectsOutputToContain("Generating batch DDL")
+            ->expectsOutputToContain("Done")
+            ->doesntExpectOutputToContain("Seeding database")
+            ->assertSuccessful()
+            ->run();
+    }
+
+    public function test_with_seed(): void
+    {
+        if(!class_exists('DatabaseSeeder'))
+            class_alias(DatabaseSeeder::class, 'DatabaseSeeder');
+
+        $this->artisan('spanner:migrate:fresh', ['--seed' => true])
+            ->expectsOutputToContain("Checking DB")
+            ->expectsOutputToContain("Dropping all tables")
+            ->expectsOutputToContain("Generating batch DDL")
+            ->expectsOutputToContain("Seeding database")
+            ->expectsOutputToContain("Done")
             ->assertSuccessful()
             ->run();
     }

--- a/tests/DatabaseSeeder.php
+++ b/tests/DatabaseSeeder.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Colopl\Spanner\Tests;
+
+use Illuminate\Database\Seeder;
+
+class DatabaseSeeder extends Seeder
+{
+	public function run(): void
+	{
+		
+	}
+}


### PR DESCRIPTION
Running migrations with spanner is very slow. This PR adds a couple of console commands

- `spanner:migrate`
- `spanner:migrate:fresh`

If you are using spanner, it will run the migrations in pretend mode, capture the output queries and convert them into batch DDL statements (and run any additional DML statements the migrations generate), resulting in massive improvements to migration duration

Also allows passing the `--seed` option as per the usual migrate commands, which calls `db:seed` when done

If you are not using spanner it falls back to using the normal `migrate` and `migrate:fresh` commands.

Added tests for both versions of the command, both with and without the `--seed` option