### PR TITLE
feat: Transaction and request tagging support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.1.0 (2024-04-16)
+
+Added
+- Request and Transaction tagging support (#206)
+
 # v8.0.0 (2024-04-11)
 
 Added

--- a/README.md
+++ b/README.md
@@ -207,8 +207,10 @@ Spanner allows you to attach tags to your queries and transactions that can be [
 You can set request tags and transaction tags as below.
 
 ```php
-$connection->setRequestTag('controller=user,action=login');
-$connection->setTransactionTag('controller=user,action=login');
+$requestPath = request()->path();
+$tag = 'url=' . $requestPath;
+$connection->setRequestTag($tag);
+$connection->setTransactionTag($tag);
 ```
 
 ### Data Types

--- a/README.md
+++ b/README.md
@@ -200,6 +200,17 @@ $queryBuilder
 > This creates a new session in the background which is not shared with the current session pool.
 > This means, queries running with data boost will not be associated with transactions that may be taking place.
 
+### Request Tags and Transaction Tags
+
+Spanner allows you to attach tags to your queries and transactions that can be [used for troubleshooting](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags).
+
+You can set request tags and transaction tags as below.
+
+```php
+$connection->setRequestTag('controller=user,action=login');
+$connection->setTransactionTag('controller=user,action=login');
+```
+
 ### Data Types
 
 Some data types of Google Cloud Spanner does not have corresponding built-in type of PHP.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,3 +44,6 @@ parameters:
         - message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
           count: 1
           path: src/Connection.php
+        - message: "#^Cannot access offset 'requestTag' on mixed\\.$#"
+          count: 1
+          path: src/Connection.php

--- a/src/Concerns/ManagesTagging.php
+++ b/src/Concerns/ManagesTagging.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Concerns;
+
+trait ManagesTagging
+{
+    /**
+     * @var string|null
+     */
+    protected ?string $requestTag = null;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $transactionTag = null;
+
+    /**
+     * @param string|null $tag
+     * @return $this
+     */
+    public function setRequestTag(?string $tag): static
+    {
+        $this->requestTag = $tag;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRequestTag(): ?string
+    {
+        return $this->requestTag;
+    }
+
+    /**
+     * @param string|null $tag
+     * @return $this
+     */
+    public function setTransactionTag(?string $tag): static
+    {
+        $this->transactionTag = $tag;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTransactionTag(): ?string
+    {
+        return $this->transactionTag;
+    }
+}

--- a/src/Concerns/ManagesTagging.php
+++ b/src/Concerns/ManagesTagging.php
@@ -23,11 +23,11 @@ trait ManagesTagging
      * @var string|null
      */
     protected ?string $requestTag = null;
-
-    /**
-     * @var string|null
-     */
-    protected ?string $transactionTag = null;
+//
+//    /**
+//     * @var string|null
+//     */
+//    protected ?string $transactionTag = null;
 
     /**
      * @param string|null $tag
@@ -46,22 +46,22 @@ trait ManagesTagging
     {
         return $this->requestTag;
     }
-
-    /**
-     * @param string|null $tag
-     * @return $this
-     */
-    public function setTransactionTag(?string $tag): static
-    {
-        $this->transactionTag = $tag;
-        return $this;
-    }
-
-    /**
-     * @return string|null
-     */
-    public function getTransactionTag(): ?string
-    {
-        return $this->transactionTag;
-    }
+//
+//    /**
+//     * @param string|null $tag
+//     * @return $this
+//     */
+//    public function setTransactionTag(?string $tag): static
+//    {
+//        $this->transactionTag = $tag;
+//        return $this;
+//    }
+//
+//    /**
+//     * @return string|null
+//     */
+//    public function getTransactionTag(): ?string
+//    {
+//        return $this->transactionTag;
+//    }
 }

--- a/src/Concerns/ManagesTagging.php
+++ b/src/Concerns/ManagesTagging.php
@@ -23,11 +23,11 @@ trait ManagesTagging
      * @var string|null
      */
     protected ?string $requestTag = null;
-//
-//    /**
-//     * @var string|null
-//     */
-//    protected ?string $transactionTag = null;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $transactionTag = null;
 
     /**
      * @param string|null $tag
@@ -46,22 +46,22 @@ trait ManagesTagging
     {
         return $this->requestTag;
     }
-//
-//    /**
-//     * @param string|null $tag
-//     * @return $this
-//     */
-//    public function setTransactionTag(?string $tag): static
-//    {
-//        $this->transactionTag = $tag;
-//        return $this;
-//    }
-//
-//    /**
-//     * @return string|null
-//     */
-//    public function getTransactionTag(): ?string
-//    {
-//        return $this->transactionTag;
-//    }
+
+    /**
+     * @param string|null $tag
+     * @return $this
+     */
+    public function setTransactionTag(?string $tag): static
+    {
+        $this->transactionTag = $tag;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTransactionTag(): ?string
+    {
+        return $this->transactionTag;
+    }
 }

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -60,10 +60,10 @@ trait ManagesTransactions
         }
 
         $options = ['maxRetries' => $attempts - 1];
-
-        if ($tag = $this->getTransactionTag()) {
-            $options['tag'] = $tag;
-        }
+//
+//        if ($tag = $this->getTransactionTag()) {
+//            $options['tag'] = $tag;
+//        }
 
         return $this->withSessionNotFoundHandling(function () use ($callback, $options) {
             $return = $this->getSpannerDatabase()->runTransaction(function (Transaction $tx) use ($callback) {

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -60,10 +60,11 @@ trait ManagesTransactions
         }
 
         $options = ['maxRetries' => $attempts - 1];
-//
-//        if ($tag = $this->getTransactionTag()) {
-//            $options['tag'] = $tag;
-//        }
+
+        $tag = $this->getTransactionTag();
+        if ($tag !== null) {
+            $options['tag'] = $tag;
+        }
 
         return $this->withSessionNotFoundHandling(function () use ($callback, $options) {
             $return = $this->getSpannerDatabase()->runTransaction(function (Transaction $tx) use ($callback) {

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -52,6 +52,7 @@ class Connection extends BaseConnection
         Concerns\ManagesMutations,
         Concerns\ManagesPartitionedDml,
         Concerns\ManagesSessionPool,
+        Concerns\ManagesTagging,
         Concerns\ManagesTransactions,
         Concerns\MarksAsNotSupported;
 
@@ -569,6 +570,11 @@ class Connection extends BaseConnection
 
         if (isset($options['dataBoostEnabled'])) {
             return $this->executePartitionedQuery($query, $options);
+        }
+
+        if ($tag = $this->getRequestTag()) {
+            $options['requestOptions'] ??= [];
+            $options['requestOptions']['requestTag'] = $tag;
         }
 
         return $this->getDatabaseContext()

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -572,14 +572,16 @@ class Connection extends BaseConnection
             return $this->executePartitionedQuery($query, $options);
         }
 
-        if ($tag = $this->getRequestTag()) {
+        $tag = $this->getRequestTag();
+        if ($tag !== null) {
             $options['requestOptions'] ??= [];
             $options['requestOptions']['requestTag'] = $tag;
         }
 
-        return $this->getDatabaseContext()
-            ->execute($query, $options)
-            ->rows();
+        if ($transaction = $this->getCurrentTransaction()) {
+            return $transaction->execute($query, $options)->rows();
+        }
+        return $this->getSpannerDatabase()->execute($query, $options)->rows();
     }
 
     /**

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Tests\Concerns;
+
+use Colopl\Spanner\Tests\TestCase;
+
+class ManagesTagsTest extends TestCase
+{
+    public function test_set_and_get_requestTag(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $conn->setRequestTag('url=/api/users');
+        $uuid = $this->generateUuid();
+        $conn->table('User')->where('userId', $uuid)->get();
+        $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
+        $conn->table('User')->where('userId', $uuid)->get();
+        $this->assertSame('url=/api/users', $conn->getRequestTag());
+        $conn->setRequestTag(null);
+        $this->assertNull($conn->getRequestTag());
+    }
+
+    public function test_set_and_get_transactionTag(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $conn->setTransactionTag('url=/api/users/update');
+        $uuid = $this->generateUuid();
+        $conn->transaction(function () use ($conn, $uuid) {
+            $conn->table('User')->where('userId', $uuid)->get();
+            $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
+            $conn->table('User')->where('userId', $uuid)->get();
+        });
+        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
+        $conn->setTransactionTag(null);
+        $this->assertNull($conn->getTransactionTag());
+    }
+}

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -26,9 +26,8 @@ class ManagesTagsTest extends TestCase
         $conn = $this->getDefaultConnection();
         $conn->setRequestTag('url=/api/users');
         $uuid = $this->generateUuid();
-        $conn->table('User')->where('userId', $uuid)->get();
         $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
-        $conn->table('User')->where('userId', $uuid)->get();
+        $conn->table('User')->where('userId', $uuid)->first();
         $this->assertSame('url=/api/users', $conn->getRequestTag());
         $conn->setRequestTag(null);
         $this->assertNull($conn->getRequestTag());
@@ -40,7 +39,6 @@ class ManagesTagsTest extends TestCase
         $conn->setTransactionTag('url=/api/users/update');
         $uuid = $this->generateUuid();
         $conn->transaction(function () use ($conn, $uuid) {
-            $conn->table('User')->where('userId', $uuid)->get();
             $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
             $conn->table('User')->where('userId', $uuid)->get();
         });

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -21,29 +21,21 @@ use Colopl\Spanner\Tests\TestCase;
 
 class ManagesTagsTest extends TestCase
 {
-//    public function test_set_and_get_requestTag(): void
-//    {
-//        $conn = $this->getDefaultConnection();
-//        $conn->setRequestTag('url=/api/users');
-//        $uuid = $this->generateUuid();
-//        $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
-//        $conn->table('User')->where('userId', $uuid)->first();
-//        $this->assertSame('url=/api/users', $conn->getRequestTag());
-//        $conn->setRequestTag(null);
-//        $this->assertNull($conn->getRequestTag());
-//    }
-//
-//    public function test_set_and_get_transactionTag(): void
-//    {
-//        $conn = $this->getDefaultConnection();
-//        $conn->setTransactionTag('url=/api/users/update');
-//        $uuid = $this->generateUuid();
-//        $conn->transaction(function () use ($conn, $uuid) {
-//            $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
-//            $conn->table('User')->where('userId', $uuid)->get();
-//        });
-//        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
-//        $conn->setTransactionTag(null);
-//        $this->assertNull($conn->getTransactionTag());
-//    }
+    public function test_set_and_get_requestTag(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $conn->setRequestTag('url=/api/users');
+        $this->assertSame('url=/api/users', $conn->getRequestTag());
+        $conn->setRequestTag(null);
+        $this->assertNull($conn->getRequestTag());
+    }
+
+    public function test_set_and_get_transactionTag(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $conn->setTransactionTag('url=/api/users/update');
+        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
+        $conn->setTransactionTag(null);
+        $this->assertNull($conn->getTransactionTag());
+    }
 }

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -17,18 +17,20 @@
 
 namespace Colopl\Spanner\Tests\Concerns;
 
+use Colopl\Spanner\Connection;
 use Colopl\Spanner\Tests\TestCase;
 
 class ManagesTagsTest extends TestCase
 {
-//    public function test_set_and_get_requestTag(): void
-//    {
-//        $conn = $this->getDefaultConnection();
-//        $conn->setRequestTag('url=/api/users');
-//        $this->assertSame('url=/api/users', $conn->getRequestTag());
-//        $conn->setRequestTag(null);
-//        $this->assertNull($conn->getRequestTag());
-//    }
+    public function test_set_and_get_requestTag(): void
+    {
+        $conn = $this->getConnection();
+        assert($conn instanceof Connection);
+        $conn->setRequestTag('url=/api/users');
+        $this->assertSame('url=/api/users', $conn->getRequestTag());
+        $conn->setRequestTag(null);
+        $this->assertNull($conn->getRequestTag());
+    }
 //
 //    public function test_set_and_get_transactionTag(): void
 //    {

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -21,29 +21,29 @@ use Colopl\Spanner\Tests\TestCase;
 
 class ManagesTagsTest extends TestCase
 {
-    public function test_set_and_get_requestTag(): void
-    {
-        $conn = $this->getDefaultConnection();
-        $conn->setRequestTag('url=/api/users');
-        $uuid = $this->generateUuid();
-        $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
-        $conn->table('User')->where('userId', $uuid)->first();
-        $this->assertSame('url=/api/users', $conn->getRequestTag());
-        $conn->setRequestTag(null);
-        $this->assertNull($conn->getRequestTag());
-    }
-
-    public function test_set_and_get_transactionTag(): void
-    {
-        $conn = $this->getDefaultConnection();
-        $conn->setTransactionTag('url=/api/users/update');
-        $uuid = $this->generateUuid();
-        $conn->transaction(function () use ($conn, $uuid) {
-            $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
-            $conn->table('User')->where('userId', $uuid)->get();
-        });
-        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
-        $conn->setTransactionTag(null);
-        $this->assertNull($conn->getTransactionTag());
-    }
+//    public function test_set_and_get_requestTag(): void
+//    {
+//        $conn = $this->getDefaultConnection();
+//        $conn->setRequestTag('url=/api/users');
+//        $uuid = $this->generateUuid();
+//        $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
+//        $conn->table('User')->where('userId', $uuid)->first();
+//        $this->assertSame('url=/api/users', $conn->getRequestTag());
+//        $conn->setRequestTag(null);
+//        $this->assertNull($conn->getRequestTag());
+//    }
+//
+//    public function test_set_and_get_transactionTag(): void
+//    {
+//        $conn = $this->getDefaultConnection();
+//        $conn->setTransactionTag('url=/api/users/update');
+//        $uuid = $this->generateUuid();
+//        $conn->transaction(function () use ($conn, $uuid) {
+//            $conn->table('User')->insert(['userId' => $uuid, 'name' => 'John Doe']);
+//            $conn->table('User')->where('userId', $uuid)->get();
+//        });
+//        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
+//        $conn->setTransactionTag(null);
+//        $this->assertNull($conn->getTransactionTag());
+//    }
 }

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -21,21 +21,21 @@ use Colopl\Spanner\Tests\TestCase;
 
 class ManagesTagsTest extends TestCase
 {
-    public function test_set_and_get_requestTag(): void
-    {
-        $conn = $this->getDefaultConnection();
-        $conn->setRequestTag('url=/api/users');
-        $this->assertSame('url=/api/users', $conn->getRequestTag());
-        $conn->setRequestTag(null);
-        $this->assertNull($conn->getRequestTag());
-    }
-
-    public function test_set_and_get_transactionTag(): void
-    {
-        $conn = $this->getDefaultConnection();
-        $conn->setTransactionTag('url=/api/users/update');
-        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
-        $conn->setTransactionTag(null);
-        $this->assertNull($conn->getTransactionTag());
-    }
+//    public function test_set_and_get_requestTag(): void
+//    {
+//        $conn = $this->getDefaultConnection();
+//        $conn->setRequestTag('url=/api/users');
+//        $this->assertSame('url=/api/users', $conn->getRequestTag());
+//        $conn->setRequestTag(null);
+//        $this->assertNull($conn->getRequestTag());
+//    }
+//
+//    public function test_set_and_get_transactionTag(): void
+//    {
+//        $conn = $this->getDefaultConnection();
+//        $conn->setTransactionTag('url=/api/users/update');
+//        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
+//        $conn->setTransactionTag(null);
+//        $this->assertNull($conn->getTransactionTag());
+//    }
 }

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -31,13 +31,14 @@ class ManagesTagsTest extends TestCase
         $conn->setRequestTag(null);
         $this->assertNull($conn->getRequestTag());
     }
-//
-//    public function test_set_and_get_transactionTag(): void
-//    {
-//        $conn = $this->getDefaultConnection();
-//        $conn->setTransactionTag('url=/api/users/update');
-//        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
-//        $conn->setTransactionTag(null);
-//        $this->assertNull($conn->getTransactionTag());
-//    }
+
+    public function test_set_and_get_transactionTag(): void
+    {
+        $conn = $this->getDefaultConnection();
+        assert($conn instanceof Connection);
+        $conn->setTransactionTag('url=/api/users/update');
+        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
+        $conn->setTransactionTag(null);
+        $this->assertNull($conn->getTransactionTag());
+    }
 }


### PR DESCRIPTION
Fix: #189 

- [ ] Backport to v7
- [x] Add documentation

Request tag from test confirmed in Query Insights
<img width="417" alt="Screenshot 2024-04-16 at 18 25 14" src="https://github.com/colopl/laravel-spanner/assets/748854/e9e48143-9a04-4747-a22d-6afadf4ed1b9">


Transaction tag from test confirmed in Transaction Insights
<img width="490" alt="Screenshot 2024-04-16 at 18 24 54" src="https://github.com/colopl/laravel-spanner/assets/748854/463c671e-7bbf-4a3a-bed5-6a72e433aab1">
