### PR TITLE
feat: allow request timeout at query level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 Added
 - Request and Transaction tagging support (#206)
 - Support for `INSERT OR IGNORE` (#207)
+- Support adding request timeout at query level (#208)
 
 # v8.0.0 (2024-04-11)
 

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ $connection->selectWithOptions('SELECT ...', $bindings, ['dataBoostEnabled' => t
 // Using Query Builder
 $queryBuilder
     ->useDataBoost()
+    ->setRequestTimeoutSeconds(60)
     ->get();
 ```
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -17,16 +17,15 @@
 
 namespace Colopl\Spanner\Query;
 
-use Closure;
 use Colopl\Spanner\Connection;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder as BaseBuilder;
-use Illuminate\Database\Query\Expression;
 use Illuminate\Support\Arr;
 use LogicException;
 
 class Builder extends BaseBuilder
 {
+    use Concerns\SetsRequestTimeouts;
     use Concerns\UsesDataBoost;
     use Concerns\UsesMutations;
     use Concerns\UsesPartitionedDml;
@@ -181,8 +180,13 @@ class Builder extends BaseBuilder
         $bindings = $this->getBindings();
         $options = [];
 
+        $requestTimeoutSeconds = $this->getRequestTimeoutSeconds();
+        if ($requestTimeoutSeconds !== null) {
+            $options['requestTimeout'] = $requestTimeoutSeconds;
+        }
+
         if ($this->dataBoostEnabled()) {
-            $options += ['dataBoostEnabled' => true];
+            $options['dataBoostEnabled'] = true;
         }
 
         if ($this->timestampBound !== null) {

--- a/src/Query/Concerns/SetsRequestTimeouts.php
+++ b/src/Query/Concerns/SetsRequestTimeouts.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Query\Concerns;
+
+trait SetsRequestTimeouts
+{
+    /**
+     * @var float|null
+     */
+    protected ?float $requestTimeoutSeconds = null;
+
+    /**
+     * @param float $seconds
+     * @return $this
+     */
+    public function setRequestTimeoutSeconds(float $seconds): static
+    {
+        $this->requestTimeoutSeconds = $seconds;
+        return $this;
+    }
+
+    /**
+     * @return float|null
+     */
+    public function getRequestTimeoutSeconds(): ?float
+    {
+        return $this->requestTimeoutSeconds;
+    }
+}


### PR DESCRIPTION
Sometimes needed for "data boosted" queries since some requests take a long time to process.

- [ ] Backport to v7.