### PR TITLE
Really basic attempt to get snapshots working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
-# v7.2.0 (Not released yet)
+# v7.3.0 (2024-04-17)
+
+Added
+- Request and Transaction tagging support (#206)
+
+# v7.2.0 (2024-03-27)
 
 Added
 - Support for `Query\Builder::upsert()` (#203)

--- a/README.md
+++ b/README.md
@@ -200,6 +200,19 @@ $queryBuilder
 > This creates a new session in the background which is not shared with the current session pool.
 > This means, queries running with data boost will not be associated with transactions that may be taking place.
 
+### Request Tags and Transaction Tags
+
+Spanner allows you to attach tags to your queries and transactions that can be [used for troubleshooting](https://cloud.google.com/spanner/docs/introspection/troubleshooting-with-tags).
+
+You can set request tags and transaction tags as below.
+
+```php
+$requestPath = request()->path();
+$tag = 'url=' . $requestPath;
+$connection->setRequestTag($tag);
+$connection->setTransactionTag($tag);
+```
+
 ### Data Types
 
 Some data types of Google Cloud Spanner does not have corresponding built-in type of PHP.

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -44,3 +44,6 @@ parameters:
         - message: "#^Expression on left side of \\?\\? is not nullable\\.$#"
           count: 1
           path: src/Connection.php
+        - message: "#^Cannot access offset 'requestTag' on mixed\\.$#"
+          count: 1
+          path: src/Connection.php

--- a/src/Concerns/ManagesTagging.php
+++ b/src/Concerns/ManagesTagging.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Concerns;
+
+trait ManagesTagging
+{
+    /**
+     * @var string|null
+     */
+    protected ?string $requestTag = null;
+
+    /**
+     * @var string|null
+     */
+    protected ?string $transactionTag = null;
+
+    /**
+     * @param string|null $tag
+     * @return $this
+     */
+    public function setRequestTag(?string $tag): static
+    {
+        $this->requestTag = $tag;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getRequestTag(): ?string
+    {
+        return $this->requestTag;
+    }
+
+    /**
+     * @param string|null $tag
+     * @return $this
+     */
+    public function setTransactionTag(?string $tag): static
+    {
+        $this->transactionTag = $tag;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTransactionTag(): ?string
+    {
+        return $this->transactionTag;
+    }
+}

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -59,7 +59,14 @@ trait ManagesTransactions
             return parent::transaction($callback, $attempts);
         }
 
-        return $this->withSessionNotFoundHandling(function () use ($callback, $attempts) {
+        $options = ['maxRetries' => $attempts - 1];
+
+        $tag = $this->getTransactionTag();
+        if ($tag !== null) {
+            $options['tag'] = $tag;
+        }
+
+        return $this->withSessionNotFoundHandling(function () use ($callback, $options) {
             $return = $this->getSpannerDatabase()->runTransaction(function (Transaction $tx) use ($callback) {
                 try {
                     $this->currentTransaction = $tx;
@@ -81,7 +88,7 @@ trait ManagesTransactions
                     $this->rollBack();
                     throw $e;
                 }
-            }, ['maxRetries' => $attempts - 1]);
+            }, $options);
 
             $this->fireConnectionEvent('committed');
 

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -21,6 +21,7 @@ use Closure;
 use Exception;
 use Google\Cloud\Core\Exception\AbortedException;
 use Google\Cloud\Spanner\Database;
+use Google\Cloud\Spanner\Snapshot;
 use Google\Cloud\Spanner\Transaction;
 use Throwable;
 
@@ -32,9 +33,9 @@ use Throwable;
 trait ManagesTransactions
 {
     /**
-     * @var Transaction|null
+     * @var Transaction|Snapshot|null
      */
-    protected ?Transaction $currentTransaction = null;
+    protected Transaction|Snapshot|null $currentTransaction = null;
 
     protected ?int $maxAttempts = null;
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -642,6 +642,20 @@ class Connection extends BaseConnection
         return $rowCount;
     }
 
+    public function snapshot($options = [], Closure $callback)
+    {
+        if($this->currentTransaction)
+            throw new Exception('Cant run a snapshot in the middle of a transaction');
+
+        $this->currentTransaction = $this->getSpannerDatabase()->snapshot($options);
+
+        $result = $callback();
+
+        $this->currentTransaction = null;
+
+        return $result;
+    }
+
     /**
      * @param string $query
      * @return bool

--- a/tests/Concerns/ManagesTagsTest.php
+++ b/tests/Concerns/ManagesTagsTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Tests\Concerns;
+
+use Colopl\Spanner\Connection;
+use Colopl\Spanner\Tests\TestCase;
+
+class ManagesTagsTest extends TestCase
+{
+    public function test_set_and_get_requestTag(): void
+    {
+        $conn = $this->getConnection();
+        assert($conn instanceof Connection);
+        $conn->setRequestTag('url=/api/users');
+        $this->assertSame('url=/api/users', $conn->getRequestTag());
+        $conn->setRequestTag(null);
+        $this->assertNull($conn->getRequestTag());
+    }
+
+    public function test_set_and_get_transactionTag(): void
+    {
+        $conn = $this->getDefaultConnection();
+        assert($conn instanceof Connection);
+        $conn->setTransactionTag('url=/api/users/update');
+        $this->assertSame('url=/api/users/update', $conn->getTransactionTag());
+        $conn->setTransactionTag(null);
+        $this->assertNull($conn->getTransactionTag());
+    }
+}


### PR DESCRIPTION
Its kind of ugly, but if I just set Connection's `currentTransaction` property to a snapshot, it works.

I had to modify the type hint of the ManagesTransaction `currentTransaction` property, then just add a `snapshot()` method to Connection that accepts an array of snapshot init options, and a closure that runs while the snapshot is active

You can use it like so

```php
$conn->snapshot(['exactStaleness' => new Duration(15)], function() {
	return Model::all();
});
```

I am sure that you can improve on this significantly, but its a start