### PR TITLE
fix: Timestamp bound queries were not applied when in transaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.1.1 (2024-06-03)
+
+Fixed
+- Timestamp bound queries were not applied when in transaction (#213)
+
 # v8.1.0 (2024-05-21)
 
 Added

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -578,9 +578,17 @@ class Connection extends BaseConnection
             $options['requestOptions']['requestTag'] = $tag;
         }
 
-        if ($transaction = $this->getCurrentTransaction()) {
+        $forceReadOnlyTransaction =
+            ($options['exactStaleness'] ?? false) ||
+            ($options['maxStaleness'] ?? false) ||
+            ($options['minReadTimestamp'] ?? false) ||
+            ($options['readTimestamp'] ?? false) ||
+            ($options['strong'] ?? false);
+
+        if (!$forceReadOnlyTransaction && $transaction = $this->getCurrentTransaction()) {
             return $transaction->execute($query, $options)->rows();
         }
+
         return $this->getSpannerDatabase()->execute($query, $options)->rows();
     }
 

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -478,7 +478,7 @@ class ConnectionTest extends TestCase
         $this->assertNotEmpty($timestamp);
 
         $timestampBound = new StrongRead();
-        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userID = ?", [$uuid], $timestampBound->transactionOptions());
+        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
         $this->assertCount(1, $rows);
         $this->assertSame($uuid, $rows[0]['userId']);
         $this->assertSame('first', $rows[0]['name']);
@@ -486,24 +486,56 @@ class ConnectionTest extends TestCase
         $oldDatetime = Carbon::instance($timestamp->get())->subSecond();
 
         $timestampBound = new ReadTimestamp($oldDatetime);
-        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userID = ?", [$uuid], $timestampBound->transactionOptions());
+        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
         $this->assertEmpty($rows);
 
         $timestampBound = new ExactStaleness(10);
-        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userID = ?", [$uuid], $timestampBound->transactionOptions());
+        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
         $this->assertEmpty($rows);
 
         $timestampBound = new MaxStaleness(10);
-        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userID = ?", [$uuid], $timestampBound->transactionOptions());
+        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
         $this->assertCount(1, $rows);
         $this->assertSame($uuid, $rows[0]['userId']);
         $this->assertSame('first', $rows[0]['name']);
 
         $timestampBound = new MinReadTimestamp($oldDatetime);
-        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userID = ?", [$uuid], $timestampBound->transactionOptions());
+        $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
         $this->assertCount(1, $rows);
         $this->assertSame($uuid, $rows[0]['userId']);
         $this->assertSame('first', $rows[0]['name']);
+    }
+
+    public function test_stale_reads_in_transaction(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $tableName = self::TABLE_NAME_USER;
+        $uuid = $this->generateUuid();
+
+        $conn->transaction(function(Connection $conn) use ($tableName, $uuid) {
+            $conn->insert("INSERT INTO {$tableName} (`userId`, `name`) VALUES ('{$uuid}', 'first')");
+            $timestampBound = new StrongRead();
+            $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
+            $this->assertEmpty($rows);
+
+            $oldDatetime = now()->subSeconds(10);
+
+            $timestampBound = new ReadTimestamp($oldDatetime);
+            $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
+            $this->assertEmpty($rows);
+
+            $timestampBound = new ExactStaleness(10);
+            $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
+            $this->assertEmpty($rows);
+
+            $timestampBound = new MaxStaleness(10);
+            $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
+            $this->assertEmpty($rows);
+
+            $timestampBound = new MinReadTimestamp($oldDatetime);
+            $rows = $conn->selectWithOptions("SELECT * FROM {$tableName} WHERE userId = ?", [$uuid], $timestampBound->transactionOptions());
+            $this->assertEmpty($rows);
+        });
     }
 
     public function testEventListenOrder(): void


### PR DESCRIPTION
Fix: #212 

- [ ] backport to 7.x