### PR TITLE
fix: updateOrInsert signature change in 11.10

### DIFF
--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -17,6 +17,7 @@
 
 namespace Colopl\Spanner\Query;
 
+use Closure;
 use Colopl\Spanner\Connection;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder as BaseBuilder;
@@ -56,6 +57,28 @@ class Builder extends BaseBuilder
         }
 
         return parent::update($values);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateOrInsert(array $attributes, array|callable $values = [])
+    {
+        $exists = $this->where($attributes)->exists();
+
+        if ($values instanceof Closure) {
+            $values = $values($exists);
+        }
+
+        if (! $exists) {
+            return $this->insert(array_merge($attributes, $values));
+        }
+
+        if (empty($values)) {
+            return true;
+        }
+
+        return (bool) $this->limit(1)->update(Arr::except($values, array_keys($attributes)));
     }
 
     /**

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -61,18 +61,6 @@ class Builder extends BaseBuilder
     /**
      * @inheritDoc
      */
-    public function updateOrInsert(array $attributes, array $values = [])
-    {
-        if (! $this->where($attributes)->exists()) {
-            return $this->insert(array_merge($attributes, $values));
-        }
-
-        return (bool) $this->take(1)->update(Arr::except($values, array_keys($attributes)));
-    }
-
-    /**
-     * @inheritDoc
-     */
     public function upsert(array $values, $uniqueBy = [], $update = null)
     {
         if (empty($values)) {


### PR DESCRIPTION
https://github.com/laravel/framework/pull/51566 broke the signature and will now throw an error.

Closes https://github.com/colopl/laravel-spanner/issues/219