### PR TITLE
feat: add Query\Builder::whereInEmbedded

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,7 @@
 # v8.2.0 (2024-06-17)
 
 Added
-- New method `Query/Builder::whereInEmbedded` to allow for querying without parameterizing queries (#)
-
+- New method `Query/Builder::whereInEmbedded` to allow for querying without parameterizing queries (#221)
 # v8.1.1 (2024-06-03)
 
 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.2.0 (2024-06-17)
+
+Added
+- New method `Query/Builder::whereInEmbedded` to allow for querying without parameterizing queries (#)
+
 # v8.1.1 (2024-06-03)
 
 Fixed

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Please note that the following are not required, but are strongly recommended fo
 ### SQL Mode
 Currently only supports Spanner running GoogleSQL (PostgreSQL mode is not supported).
 
+### Query
+- [Binding more than 950 parameters in a single query will result in an error](https://cloud.google.com/spanner/quotas#query-limits)
+  by the server. You may by-pass this limitation by using `Query\Builder::whereInEmbedded(...)` method to embed the
+  values instead of using query parameters. Using this method may have [negative impact on performance and security](https://cloud.google.com/spanner/docs/sql-best-practices#query-parameters).
+
 ### Eloquent
 If you use interleaved keys, you MUST define them in the `interleaveKeys` property, or else you won't be able to save. 
 For more detailed instructions, see `Colopl\Spanner\Tests\Eloquent\ModelTest`.

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ Currently only supports Spanner running GoogleSQL (PostgreSQL mode is not suppor
 - [Binding more than 950 parameters in a single query will result in an error](https://cloud.google.com/spanner/quotas#query-limits)
   by the server. You may by-pass this limitation by using `Query\Builder::whereInEmbedded(...)` method to embed the
   values instead of using query parameters. Using this method may have [negative impact on performance and security](https://cloud.google.com/spanner/docs/sql-best-practices#query-parameters).
-
+  Please ensure to review the security practices when using this method, especially regarding SQL injection risks.
 ### Eloquent
 If you use interleaved keys, you MUST define them in the `interleaveKeys` property, or else you won't be able to save. 
 For more detailed instructions, see `Colopl\Spanner\Tests\Eloquent\ModelTest`.

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -166,6 +166,19 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * @param string $column
+     * @param iterable<array-key, scalar> $values
+     * @return $this
+     */
+    public function whereInEmbedded(string $column, iterable $values): static
+    {
+        $rawColumn = $this->getGrammar()->wrap($column);
+        $rawValues = implode(', ', array_map($this->connection->escape(...), iterator_to_array($values)));
+        $this->whereRaw("{$rawColumn} in ({$rawValues})");
+        return $this;
+    }
+
+    /**
      * @param array<array-key, mixed> $values
      * @return array<int, mixed>
      */


### PR DESCRIPTION
This will allow users to use whereIn without the fear of reaching the 950 query parameter limit.

- [ ] backport to 7.x

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new query method to embed values directly, enhancing flexibility in building WHERE IN clauses.

- **Documentation**
  - Updated README to explain the new method and its potential performance and security implications.

- **Tests**
  - Added tests to ensure the new query method handles large parameter sets effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->