### PR TITLE
fix: phpstan error for string('column', 'MAX')

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+# v8.1.3 (2024-06-24)
+
+Fixed
+- phpstan error for string('column', 'MAX') (#223)
+
+# v8.1.2 (2024-06-10)
+
+Fixed
+- updateOrInsert signature change in 11.10 (#216)
+
 # v8.1.1 (2024-06-03)
 
 Fixed

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -45,3 +45,6 @@ parameters:
         - message: "#^Cannot access offset 'requestTag' on mixed\\.$#"
           count: 1
           path: src/Connection.php
+        - message: "#^Parameter \\#2 \\$length of method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:string\\(\\) expects int\\|null, int\\|string\\|null given\\.$#"
+          count: 1
+          path: src/Schema/Blueprint.php

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -113,6 +113,15 @@ class Blueprint extends BaseBlueprint
 
     /**
      * @inheritDoc
+     * @param int|'max'|null $length add support for 'max'
+     */
+    public function string($column, $length = null)
+    {
+        return parent::string($column, $length);
+    }
+
+    /**
+     * @inheritDoc
      * @return UuidColumnDefinition
      */
     public function uuid($column = 'uuid')


### PR DESCRIPTION
Fix: #218 

## Checklist

- [x] CHANGELOG

## Reference



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Resolved a PHPStan error related to a type mismatch in the `string()` method of the `Blueprint` class.
	- Updated the method signature for `updateOrInsert` in version 8.1.2 for enhanced compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->