### PR TITLE
fix: migration broke in laravel v11.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 > [!NOTE] Minimum supported Laravel version is bumped to 11.15.0 for #224.
 
-Fixed
 - Fixed an issue where Schema changes were applied twice. (#224)
 
 # v8.1.3 (2024-06-24)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # v8.2.0 (2024-08-05)
 
+> [!NOTE] Minimum supported Laravel version is bumped to 11.15.0 for #224.
+
 Fixed
-- Fixed an issue where Schema changes were applied twice. (#)
+- Fixed an issue where Schema changes were applied twice. (#224)
 
 # v8.1.3 (2024-06-24)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v8.2.0 (2024-08-05)
+
+Fixed
+- Fixed an issue where Schema changes were applied twice. (#)
+
 # v8.1.3 (2024-06-24)
 
 Fixed

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.2",
     "ext-grpc": "*",
     "ext-json": "*",
-    "laravel/framework": "^11",
+    "laravel/framework": "^11.15.0",
     "google/cloud-spanner": "^1.58.4",
     "grpc/grpc": "^1.42",
     "symfony/cache": "~7",

--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -24,7 +24,7 @@ use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;
 
 /**
- * @mixin Builder
+ * @mixin Builder<static>
  */
 class Model extends BaseModel
 {
@@ -42,7 +42,7 @@ class Model extends BaseModel
     public $incrementing = false;
 
     /**
-     * @param BaseModel|Relation $query
+     * @param BaseModel|Relation<BaseModel, $this, BaseModel> $query
      * @param mixed $value
      * @param string|null $field
      * @return BuilderContract
@@ -59,7 +59,7 @@ class Model extends BaseModel
      * @param  string  $childType
      * @param  mixed  $value
      * @param  string|null  $field
-     * @return Relation
+     * @return Relation<BaseModel, $this, *>
      */
     protected function resolveChildRouteBindingQuery($childType, $value, $field)
     {

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -115,14 +115,19 @@ class Grammar extends BaseGrammar
      *
      * @param  Blueprint  $blueprint
      * @param  Fluent<string, mixed> $command
-     * @return string[]
+     * @return list<string>|string
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
     {
-        return $this->prefixArray(
-            'alter table '.$this->wrapTable($blueprint).' add column',
-            $this->getColumns($blueprint)
+        $column = $command->column;
+
+        $sql = sprintf('alter table %s add column %s %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($column),
+            $this->getType($column),
         );
+
+        return $this->addModifiers($sql, $blueprint, $column);
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -131,14 +131,19 @@ class Grammar extends BaseGrammar
      * @param  Blueprint  $blueprint
      * @param  Fluent<string, mixed> $command
      * @param  Connection $connection
-     * @return string[]
+     * @return list<string>|string
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {
-       return $this->prefixArray(
-            'alter table '.$this->wrapTable($blueprint).' alter column',
-            $this->getChangedColumns($blueprint)
+        $column = $command->column;
+
+        $sql = sprintf('alter table %s alter column %s %s',
+            $this->wrapTable($blueprint),
+            $this->wrap($column),
+            $this->getType($column),
         );
+
+        return $this->addModifiers($sql, $blueprint, $column);
     }
 
     /**
@@ -829,6 +834,8 @@ class Grammar extends BaseGrammar
 
     /**
      * Compile the blueprint's column definitions.
+     *
+     * @deprecated Not used anymore. Will be deleted in 9.x.
      *
      * @param  Blueprint $blueprint
      * @return array<int, string>


### PR DESCRIPTION
Broke when https://github.com/laravel/framework/pull/51373 was merged.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Updated the minimum supported version of Laravel to 11.15.0 for improved compatibility.
- **Bug Fixes**
	- Resolved an issue where schema changes were applied twice, enhancing application functionality.
- **Documentation**
	- Added a new entry in the CHANGELOG for version 8.2.0 to clarify updates and requirements.
	- Improved type hinting and documentation within the Model class for better developer experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->