### PR TITLE
feat: use UNNEST to bypass parameter limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # v8.3.0 (2024-09-02)
 
 - add support for `Query\Builder::whereNotInUnnest(...)` (#225)
+- `Query\Builder::whereIn` will now wrap values in `UNNEST` if the number of values exceeds the limit (950). (#)
 
 # v8.2.0 (2024-08-05)
 

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ Currently only supports Spanner running GoogleSQL (PostgreSQL mode is not suppor
 
 ### Query
 - [Binding more than 950 parameters in a single query will result in an error](https://cloud.google.com/spanner/quotas#query-limits)
-  by the server. You may by-pass this limitation by using `Query\Builder::whereInUnnest(...)` method to pass the values
-  as an array and unnest them on the server side instead of using query parameters.
+  by the server. In order to by-pass this limitation, this driver will attempt to switch to using `Query\Builder::whereInUnnest(...)`
+  internally when the passed parameter exceeds the limit set by `parameter_unnest_threshold` config (default: `900`).
+  You can turn this feature off by setting the value to `false`.
 
 ### Eloquent
 If you use interleaved keys, you MUST define them in the `interleaveKeys` property, or else you won't be able to save. 

--- a/README.md
+++ b/README.md
@@ -409,4 +409,3 @@ make test
 
 ## License
 Apache 2.0 - See [LICENSE](./LICENSE) for more information.
-

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -48,3 +48,6 @@ parameters:
         - message: "#^Parameter \\#2 \\$length of method Illuminate\\\\Database\\\\Schema\\\\Blueprint\\:\\:string\\(\\) expects int\\|null, int\\|string\\|null given\\.$#"
           count: 1
           path: src/Schema/Blueprint.php
+        - message: "#^Parameter \\#1 \\$array of class Colopl\\\\Spanner\\\\Query\\\\Nested constructor expects array\\<int, mixed\\>\\|Illuminate\\\\Contracts\\\\Support\\\\Arrayable\\<int, mixed\\>, mixed given\\.$#"
+          count: 1
+          path: src/Query/Builder.php

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -130,10 +130,9 @@ class Builder extends BaseBuilder
     {
         // If parameter is over the limit, Spanner will throw an error. We will bypass this limit by
         // using UNNEST(). This is enabled by default, but can be disabled by setting the config.
-        if (is_countable($values) && count($values) > self::PARAMETER_LIMIT) {
-            if ($this->connection->getConfig('use_unnest_on_parameter_overflow') ?? true) {
-                return $this->whereInUnnest($column, $values, $boolean, $not);
-            }
+        $unnestThreshold = $this->connection->getConfig('parameter_unnest_threshold') ?? 900;
+        if ($unnestThreshold !== false && is_countable($values) && count($values) > $unnestThreshold) {
+            return $this->whereInUnnest($column, $values, $boolean, $not);
         }
 
         return parent::whereIn($column, $values, $boolean, $not);

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -19,6 +19,7 @@ namespace Colopl\Spanner\Query;
 
 use Closure;
 use Colopl\Spanner\Connection;
+use Illuminate\Contracts\Database\Query\Expression;
 use Illuminate\Contracts\Support\Arrayable;
 use Illuminate\Database\Query\Builder as BaseBuilder;
 use Illuminate\Support\Arr;
@@ -31,6 +32,8 @@ class Builder extends BaseBuilder
     use Concerns\UsesMutations;
     use Concerns\UsesPartitionedDml;
     use Concerns\UsesStaleReads;
+
+    public const PARAMETER_LIMIT = 950;
 
     /**
      * @var Connection
@@ -121,6 +124,22 @@ class Builder extends BaseBuilder
     }
 
     /**
+     * @inheritDoc
+     */
+    public function whereIn($column, $values, $boolean = 'and', $not = false)
+    {
+        // If parameter is over the limit, Spanner will throw an error. We will bypass this limit by
+        // using UNNEST(). This is enabled by default, but can be disabled by setting the config.
+        if (is_countable($values) && count($values) > self::PARAMETER_LIMIT) {
+            if ($this->connection->getConfig('use_unnest_on_parameter_overflow') ?? true) {
+                return $this->whereInUnnest($column, $values, $boolean, $not);
+            }
+        }
+
+        return parent::whereIn($column, $values, $boolean, $not);
+    }
+
+    /**
      * NOTE: We will attempt to bind column names included in UNNEST() here.
      * @see https://cloud.google.com/spanner/docs/lexical#query-parameters
      * > Query parameters can be used in substitution of arbitrary expressions.
@@ -146,12 +165,13 @@ class Builder extends BaseBuilder
     }
 
     /**
-     * @param string $column
-     * @param array<array-key, mixed>|Arrayable<array-key, mixed>|Nested $values
+     * @param string|Expression $column
+     * @param mixed $values
      * @param string $boolean
+     * @param bool $not
      * @return $this
      */
-    public function whereInUnnest(string $column, $values, string $boolean = 'and', bool $not = false)
+    public function whereInUnnest(string|Expression $column, $values, string $boolean = 'and', bool $not = false)
     {
         $type = 'InUnnest';
 

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -34,6 +34,7 @@ class Builder extends BaseBuilder
     use Concerns\UsesStaleReads;
 
     public const PARAMETER_LIMIT = 950;
+    public const DEFAULT_UNNEST_THRESHOLD = 900;
 
     /**
      * @var Connection
@@ -130,7 +131,7 @@ class Builder extends BaseBuilder
     {
         // If parameter is over the limit, Spanner will throw an error. We will bypass this limit by
         // using UNNEST(). This is enabled by default, but can be disabled by setting the config.
-        $unnestThreshold = $this->connection->getConfig('parameter_unnest_threshold') ?? 900;
+        $unnestThreshold = $this->connection->getConfig('parameter_unnest_threshold') ?? self::DEFAULT_UNNEST_THRESHOLD;
         if ($unnestThreshold !== false && is_countable($values) && count($values) > $unnestThreshold) {
             return $this->whereInUnnest($column, $values, $boolean, $not);
         }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1099,7 +1099,7 @@ class BuilderTest extends TestCase
         $this->expectExceptionMessage('Number of parameters in query exceeds the maximum allowed limit of 950.');
         $this->expectException(QueryException::class);
 
-        config()->set('database.connections.main.use_unnest_on_parameter_overflow', false);
+        config()->set('database.connections.main.parameter_unnest_threshold', false);
         $query = $this->getDefaultConnection()->table(self::TABLE_NAME_USER);
         $query->whereIn('userId', array_map(Uuid::uuid4()->toString(...), range(1, 1000)))->get();
     }

--- a/tests/Query/BuilderTest.php
+++ b/tests/Query/BuilderTest.php
@@ -1090,7 +1090,7 @@ class BuilderTest extends TestCase
     {
         $query = $this->getDefaultConnection()->table(self::TABLE_NAME_USER);
         $query->whereIn('userId', array_map(Uuid::uuid4()->toString(...), range(1, 1000)));
-        $this->assertSame([], $query->get());
+        $this->assertSame([], $query->get()->all());
     }
 
 


### PR DESCRIPTION
Tried running WHERE IN UNNEST with 1000 parameters and here is the result.

<img width="1226" alt="Screenshot 2024-09-03 at 16 59 13" src="https://github.com/user-attachments/assets/e646a145-6b4a-4cec-b41c-fe03d10c3ca3">

Index scan is used and everything seems to be working fine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a new method to the query builder for excluding values in complex queries.
	- Enhanced the existing method to automatically handle large sets of values for improved performance.

- **Documentation**
	- Updated documentation to clarify handling of query parameters exceeding limits and introduced a configuration option for users.

- **Tests**
	- Added new tests to ensure correct functionality of the query builder under different configurations related to parameter limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->