### PR TITLE
feat: deprecate Connection::getDatabaseContext and rename to getMutationExecutor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # v8.3.0 (2024-09-02)
 
+- deprecate Connection::getDatabaseContext() and move logic to UseMutations::getMutationExecutor() (#227)
 - add support for `Query\Builder::whereNotInUnnest(...)` (#225)
 - `Query\Builder::whereIn` will now wrap values in `UNNEST` if the number of values exceeds the limit (950). (#)
 

--- a/src/Concerns/ManagesMutations.php
+++ b/src/Concerns/ManagesMutations.php
@@ -45,7 +45,7 @@ trait ManagesMutations
         $this->withTransactionEvents(function () use ($table, $dataSet) {
             $dataSet = $this->prepareForMutation($dataSet);
             $this->event(new MutatingData($this, $table, 'insert', $dataSet));
-            $this->getDatabaseContext()->insertBatch($table, $dataSet);
+            $this->getMutationExecutor()->insertBatch($table, $dataSet);
         });
     }
 
@@ -59,7 +59,7 @@ trait ManagesMutations
         $this->withTransactionEvents(function () use ($table, $dataSet) {
             $dataSet = $this->prepareForMutation($dataSet);
             $this->event(new MutatingData($this, $table, 'update', $dataSet));
-            $this->getDatabaseContext()->updateBatch($table, $dataSet);
+            $this->getMutationExecutor()->updateBatch($table, $dataSet);
         });
     }
 
@@ -73,7 +73,7 @@ trait ManagesMutations
         $this->withTransactionEvents(function () use ($table, $dataSet) {
             $dataSet = $this->prepareForMutation($dataSet);
             $this->event(new MutatingData($this, $table, 'update', $dataSet));
-            $this->getDatabaseContext()->insertOrUpdateBatch($table, $dataSet);
+            $this->getMutationExecutor()->insertOrUpdateBatch($table, $dataSet);
         });
     }
 
@@ -88,8 +88,16 @@ trait ManagesMutations
             $keySet = $this->createDeleteMutationKeySet($keySet);
             $dataSet = $keySet->keys() ?: $keySet->keySetObject();
             $this->event(new MutatingData($this, $table, 'delete', $dataSet));
-            $this->getDatabaseContext()->delete($table, $keySet);
+            $this->getMutationExecutor()->delete($table, $keySet);
         });
+    }
+
+    /**
+     * @return Database|Transaction
+     */
+    protected function getMutationExecutor(): Database|Transaction
+    {
+        return $this->getCurrentTransaction() ?? $this->getSpannerDatabase();
     }
 
     /**

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -128,7 +128,7 @@ class Connection extends BaseConnection
     }
 
     /**
-     * @deprecated will be removed in v9
+     * @deprecated will be removed in v10
      * @return Database|Transaction
      */
     protected function getDatabaseContext(): Database|Transaction

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -128,6 +128,7 @@ class Connection extends BaseConnection
     }
 
     /**
+     * @deprecated will be removed in v9
      * @return Database|Transaction
      */
     protected function getDatabaseContext(): Database|Transaction


### PR DESCRIPTION
The only ones using it now is the mutation trait, so just move it there.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
  - Introduced a new method for query building, enhancing query capabilities.

- **Improvements**
  - Updated database operation methods for better mutation handling.
  - Optimized the `whereIn` method to improve query performance with large data sets.

- **Deprecations**
  - Deprecated the `getDatabaseContext()` method in favor of a new centralized mutation execution approach.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->