### PR TITLE
feat: allow commit options to be set from config and Connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 - add support for snapshot queries (#215)
 - deprecate Connection::getDatabaseContext() and move logic to UseMutations::getMutationExecutor() (#227)
 - add support for `Query\Builder::whereNotInUnnest(...)` (#225)
-- `Query\Builder::whereIn` will now wrap values in `UNNEST` if the number of values exceeds the limit (950). (#)
+- `Query\Builder::whereIn` will now wrap values in `UNNEST` if the number of values exceeds the limit (950). (#226)
+- Commit options can now be set through config or through `Connection::setCommitOptions(...)` (#229)
 
 # v8.2.0 (2024-08-05)
 

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -40,6 +40,11 @@ trait ManagesTransactions
     protected ?int $maxAttempts = null;
 
     /**
+     * @var array|null $commitOptions
+     */
+    protected ?array $commitOptions = null;
+
+    /**
      * @inheritDoc
      * @template T
      * @param  Closure(static): T $callback
@@ -158,7 +163,7 @@ trait ManagesTransactions
     {
         if ($this->transactions === 1 && $this->currentTransaction !== null) {
             $this->fireConnectionEvent('committing');
-            $this->currentTransaction->commit();
+            $this->currentTransaction->commit($this->getCommitOptions());
         }
 
         [$levelBeingCommitted, $this->transactions] = [
@@ -262,5 +267,22 @@ trait ManagesTransactions
     {
         $this->maxAttempts = $attempts;
         return $this;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function getCommitOptions(): array
+    {
+        return $this->commitOptions ??= $this->getConfig('commit') ?? [];
+    }
+
+    /**
+     * @param array<string, mixed> $options
+     * @return void
+     */
+    public function setCommitOptions(array $options): void
+    {
+        $this->commitOptions = $options;
     }
 }

--- a/src/Concerns/ManagesTransactions.php
+++ b/src/Concerns/ManagesTransactions.php
@@ -274,7 +274,13 @@ trait ManagesTransactions
      */
     public function getCommitOptions(): array
     {
-        return $this->commitOptions ??= $this->getConfig('commit') ?? [];
+        if ($this->commitOptions !== null) {
+            return $this->commitOptions;
+        }
+
+        $options = $this->getConfig('commit') ?? [];
+        assert(is_array($options));
+        return $this->commitOptions = $options;
     }
 
     /**

--- a/tests/TransactionTest.php
+++ b/tests/TransactionTest.php
@@ -98,7 +98,6 @@ class TransactionTest extends TestCase
             return $conn->getCurrentTransaction();
         });
         $this->assertNotNull($tx);
-        dump($tx->getCommitStats());
         $this->assertSame([], $tx->getCommitStats());
         $this->assertSame([], $conn->getCommitOptions());
 


### PR DESCRIPTION
Closes #205 

Requires the real Spanner to test this fully.

Feature request has been sent to emulator so it can be tested locally.
https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/issues/184


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added support for snapshot queries to enhance query capabilities.
	- Introduced `whereNotInUnnest(...)` method in the query builder.
	- Added configurable commit options through a configuration file or method.

- **Improvements**
	- Updated `whereIn(...)` method to handle large value sets efficiently by using `UNNEST`.
	- Enhanced transaction management with new methods for getting and setting commit options.

- **Tests**
	- Added tests for committing transactions with specific options to ensure functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->