### PR TITLE
Fix Grammar::substituteBindingsIntoRawSql fails during unnesting

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -20,6 +20,7 @@ namespace Colopl\Spanner;
 use Closure;
 use Colopl\Spanner\Query\Builder as QueryBuilder;
 use Colopl\Spanner\Query\Grammar as QueryGrammar;
+use Colopl\Spanner\Query\Nested;
 use Colopl\Spanner\Query\Parameterizer as QueryParameterizer;
 use Colopl\Spanner\Query\Processor as QueryProcessor;
 use Colopl\Spanner\Schema\Builder as SchemaBuilder;
@@ -445,10 +446,14 @@ class Connection extends BaseConnection
 
     /**
      * @inheritDoc
-     * @param scalar|list<mixed>|null $value
+     * @param scalar|list<mixed>|Nested|null $value
      */
     public function escape($value, $binary = false)
     {
+        if ($value instanceof Nested) {
+            $value = $value->toArray();
+        }
+
         return is_array($value)
             ? $this->escapeArray($value, $binary)
             : parent::escape($value, $binary);

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -195,4 +195,17 @@ class Grammar extends BaseGrammar
     {
         return false;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function substituteBindingsIntoRawSql($sql, $bindings)
+    {
+        $bindings = array_map(
+            static fn(mixed $binding): mixed => $binding instanceof Nested ? $binding->toArray() : $binding,
+            $bindings
+        );
+
+        return parent::substituteBindingsIntoRawSql($sql, $bindings);
+    }
 }

--- a/src/Query/Grammar.php
+++ b/src/Query/Grammar.php
@@ -195,17 +195,4 @@ class Grammar extends BaseGrammar
     {
         return false;
     }
-
-    /**
-     * @inheritDoc
-     */
-    public function substituteBindingsIntoRawSql($sql, $bindings)
-    {
-        $bindings = array_map(
-            static fn(mixed $binding): mixed => $binding instanceof Nested ? $binding->toArray() : $binding,
-            $bindings
-        );
-
-        return parent::substituteBindingsIntoRawSql($sql, $bindings);
-    }
 }

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -19,6 +19,7 @@ namespace Colopl\Spanner\Tests;
 
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Events\MutatingData;
+use Colopl\Spanner\Query\Nested;
 use Colopl\Spanner\Session\SessionInfo;
 use Colopl\Spanner\TimestampBound\ExactStaleness;
 use Colopl\Spanner\TimestampBound\MaxStaleness;
@@ -598,6 +599,15 @@ class ConnectionTest extends TestCase
 
         $conn = $this->getDefaultConnection();
         $this->assertSame('[]', $conn->escape([[]]));
+    }
+
+    public function test_escape_nested_object(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $this->assertSame(
+            "[false, true, 0, 1, \"a\", 1.1]",
+            $conn->escape(new Nested([false, true, 0, 1, "a", 1.1]))
+        );
     }
 
     public function test_getTablePrefix(): void

--- a/tests/Query/UnnestTest.php
+++ b/tests/Query/UnnestTest.php
@@ -100,42 +100,4 @@ class UnnestTest extends TestCase
         $this->assertCount(2, $results);
         $this->assertSame($ids->skip(1)->values()->all(), $results->all());
     }
-
-    public function test_substituteBindingsIntoRawSql(): void
-    {
-        $conn = $this->getDefaultConnection();
-        $grammar = $conn->getQueryGrammar();
-        $tableName = self::TABLE_NAME_USER;
-        $keyName = 'userId';
-
-        $normalId = $this->generateUuid();
-        $unnestIds = array_map($this->generateUuid(...), range(0, self::SPANNER_PARAMETERS_LIMIT));
-
-        foreach ([$normalId, ...$unnestIds] as $i => $id) {
-            $conn->table($tableName)->insert([[$keyName => $id, 'name' => "user" . $i]]);
-        }
-
-        $conn->enableQueryLog();
-
-        $conn->table($tableName)->where($keyName, $normalId)->delete();
-        $conn->table($tableName)->whereIn($keyName, $unnestIds)->delete();
-
-        $logs = $conn->getQueryLog();
-
-        $this->assertCount(2, $logs);
-
-        $logFirst = $logs[0];
-        $logSecond = $logs[1];
-
-        $this->assertSame(
-            "delete from `{$tableName}` where `{$keyName}` = \"{$normalId}\"",
-            $grammar->substituteBindingsIntoRawSql($logFirst['query'], $logFirst['bindings'])
-        );
-
-        $whereInIds = collect($unnestIds)->map(static fn($userId): string => "\"{$userId}\"")->join(', ');
-        $this->assertSame(
-            "delete from `{$tableName}` where `{$keyName}` in unnest([{$whereInIds}])",
-            $grammar->substituteBindingsIntoRawSql($logSecond['query'], $logSecond['bindings'])
-        );
-    }
 }

--- a/tests/Query/UnnestTest.php
+++ b/tests/Query/UnnestTest.php
@@ -21,6 +21,7 @@ use Colopl\Spanner\Tests\TestCase;
 
 class UnnestTest extends TestCase
 {
+    /** @see https://cloud.google.com/spanner/quotas#query_limits */
     public const SPANNER_PARAMETERS_LIMIT = 950;
 
     public function test_whereInUnnest(): void
@@ -127,7 +128,7 @@ class UnnestTest extends TestCase
         $logSecond = $logs[1];
 
         $this->assertSame(
-            "delete from `{$tableName}` where `{$keyName}` = \"$normalId\"",
+            "delete from `{$tableName}` where `{$keyName}` = \"{$normalId}\"",
             $grammar->substituteBindingsIntoRawSql($logFirst['query'], $logFirst['bindings'])
         );
 


### PR DESCRIPTION
change #226 it possible for instances of `Colopl\Spanner\Query\Nested` objects to be included in the `bindings` of `Connection::getQueryLog()` when using UNNEST capable methods like `whereIn`. However, the Grammar was not compatible with this change. 

This PR fixes object handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced parameter handling in query methods
	- Improved support for nested data structures in database connections

- **Tests**
	- Added new test for SQL binding substitution
	- Introduced constant for parameter limit testing

- **Improvements**
	- Updated method signatures to support more flexible input types
<!-- end of auto-generated comment: release notes by coderabbit.ai -->