### PR TITLE
chore: phpstan errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,8 +7,6 @@ parameters:
         - '#^Return type \(void\) of method .*? should be compatible with return type \(.*?\) of method .*?$#'
         - message: '#^Method Colopl\\Spanner\\Connection::runPartitionedDml\(\) should return int but returns mixed\.$#'
           path: src/Concerns/ManagesPartitionedDml.php
-        - message: '#^Unable to resolve the template type TKey in call to function collect$#'
-          path: src/Concerns/ManagesSessionPool.php
         - message: '#^Parameter \#1 \$pdo of method Illuminate\\Database\\Connection::__construct\(\) expects Closure|PDO, null given\.$#'
           path: src/Connection.php
         - message: '#^Method Colopl\\Spanner\\Connection::selectWithOptions\(\) should return array<int, array> but returns mixed\.$#'

--- a/src/Concerns/ManagesSessionPool.php
+++ b/src/Concerns/ManagesSessionPool.php
@@ -87,10 +87,12 @@ trait ManagesSessionPool
 
         $response = (new ProtobufSpannerClient($config))->listSessions($databaseName);
 
-        return collect($response->iterateAllElements())->map(function ($session) {
+        $sessions = [];
+        foreach ($response->iterateAllElements() as $session) {
             assert($session instanceof ProtobufSpannerSession);
-            return new SessionInfo($session);
-        });
+            $sessions[] = new SessionInfo($session);
+        }
+        return new Collection($sessions);
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -114,7 +114,7 @@ class Grammar extends BaseGrammar
      *
      * @param Blueprint  $blueprint
      * @param Fluent<string, mixed>&object{ column: ColumnDefinition } $command
-     * @return list<string>|string
+     * @return string
      */
     public function compileAdd(Blueprint $blueprint, Fluent $command)
     {
@@ -135,7 +135,7 @@ class Grammar extends BaseGrammar
      * @param Blueprint $blueprint
      * @param Fluent<string, mixed>&object{ column: ColumnDefinition } $command
      * @param Connection $connection
-     * @return list<string>|string
+     * @return string
      */
     public function compileChange(Blueprint $blueprint, Fluent $command, Connection $connection)
     {

--- a/tests/Console/CooldownCommandTest.php
+++ b/tests/Console/CooldownCommandTest.php
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-namespace Console;
+namespace Colopl\Spanner\Tests\Console;
 
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Tests\Console\TestCase;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved a static analysis configuration issue in PHPStan
  - Updated return type annotations for schema grammar methods

- **Refactor**
  - Modified session list collection handling in `ManagesSessionPool` trait
  - Updated test class namespace for better organization

- **Chores**
  - Improved type consistency in schema-related methods

<!-- end of auto-generated comment: release notes by coderabbit.ai -->