### PR TITLE
chore: add better phpdoc to TimestampBound

### DIFF
--- a/src/TimestampBound/ExactStaleness.php
+++ b/src/TimestampBound/ExactStaleness.php
@@ -42,10 +42,7 @@ class ExactStaleness implements TimestampBoundInterface
     }
 
     /**
-     * transactionOptions is used for $options on read/query or read-only transaction (ex. Database::snapshot)
-     *
-     * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions
-     * @return array
+     * @inheritDoc
      */
     public function transactionOptions(): array
     {

--- a/src/TimestampBound/MaxStaleness.php
+++ b/src/TimestampBound/MaxStaleness.php
@@ -42,10 +42,7 @@ class MaxStaleness implements TimestampBoundInterface
     }
 
     /**
-     * transactionOptions is used for $options on read/query or read-only transaction (ex. Database::snapshot)
-     *
-     * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions
-     * @return array
+     * @inheritDoc
      */
     public function transactionOptions(): array
     {

--- a/src/TimestampBound/MinReadTimestamp.php
+++ b/src/TimestampBound/MinReadTimestamp.php
@@ -39,10 +39,7 @@ class MinReadTimestamp implements TimestampBoundInterface
     }
 
     /**
-     * transactionOptions is used for $options on read/query or read-only transaction (ex. Database::snapshot)
-     *
-     * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions
-     * @return array
+     * @inheritDoc
      */
     public function transactionOptions(): array
     {

--- a/src/TimestampBound/ReadTimestamp.php
+++ b/src/TimestampBound/ReadTimestamp.php
@@ -39,10 +39,7 @@ class ReadTimestamp implements TimestampBoundInterface
     }
 
     /**
-     * transactionOptions is used for $options on read/query or read-only transaction (ex. Database::snapshot)
-     *
-     * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions
-     * @return array
+     * @inheritDoc
      */
     public function transactionOptions(): array
     {

--- a/src/TimestampBound/StrongRead.php
+++ b/src/TimestampBound/StrongRead.php
@@ -20,10 +20,7 @@ namespace Colopl\Spanner\TimestampBound;
 class StrongRead implements TimestampBoundInterface
 {
     /**
-     * transactionOptions is used for $options on read/query or read-only transaction (ex. Database::snapshot)
-     *
-     * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions
-     * @return array
+     * @inheritDoc
      */
     public function transactionOptions(): array
     {

--- a/src/TimestampBound/TimestampBoundInterface.php
+++ b/src/TimestampBound/TimestampBoundInterface.php
@@ -17,6 +17,9 @@
 
 namespace Colopl\Spanner\TimestampBound;
 
+use Google\Cloud\Spanner\Duration;
+use Google\Cloud\Spanner\Timestamp;
+
 /**
  * TimestampBound defines how Cloud Spanner will choose a timestamp for a single read/query or read-only transaction.
  */
@@ -26,7 +29,15 @@ interface TimestampBoundInterface
      * transactionOptions is used for $options on read/query or read-only transaction (ex. Database::snapshot)
      *
      * @see https://cloud.google.com/spanner/docs/reference/rpc/google.spanner.v1#google.spanner.v1.TransactionOptions
-     * @return array
+     * 
+     * @return array{
+     *     returnReadTimestamp?: bool,
+     *     strong?: bool,
+     *     minReadTimestamp?: Timestamp,
+     *     maxStaleness?: Duration,
+     *     readTimestamp?: Timestamp,
+     *     exactStaleness?: Duration,
+     * }
      */
     public function transactionOptions(): array;
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
	- Updated method documentation across multiple timestamp bound classes to use `@inheritDoc`
	- Enhanced return type specification in `TimestampBoundInterface`
	- Added new use statements for `Duration` and `Timestamp` classes

- **Refactor**
	- Simplified method documentation by inheriting from parent interface
	- Improved type hinting for transaction options array

<!-- end of auto-generated comment: release notes by coderabbit.ai -->