### PR TITLE
chore: remove unused option "useGapicBackoffs"

### DIFF
--- a/src/SpannerServiceProvider.php
+++ b/src/SpannerServiceProvider.php
@@ -103,7 +103,6 @@ class SpannerServiceProvider extends ServiceProvider
             'name' => $name,
             'cache_path' => null,
             'session_pool' => [],
-            'useGapicBackoffs' => true,
         ];
     }
 


### PR DESCRIPTION
`useGapicBackoffs` no longer exists in SpannerClient.