### PR TITLE
chore: update laravel to 11.31 to avoid security vulnerability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "php": "^8.2",
     "ext-grpc": "*",
     "ext-json": "*",
-    "laravel/framework": "^11.15.0",
+    "laravel/framework": "^11.31.0",
     "google/cloud-spanner": "^1.58.4",
     "grpc/grpc": "^1.42",
     "symfony/cache": "~7",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Dependency Update**
  - Updated Laravel framework version to the latest compatible release (^11.31.0)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->