### PR TITLE
feat: use expected type for Connection::__construct() to bypass phpstan errors

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -7,8 +7,6 @@ parameters:
         - '#^Return type \(void\) of method .*? should be compatible with return type \(.*?\) of method .*?$#'
         - message: '#^Method Colopl\\Spanner\\Connection::runPartitionedDml\(\) should return int but returns mixed\.$#'
           path: src/Concerns/ManagesPartitionedDml.php
-        - message: '#^Parameter \#1 \$pdo of method Illuminate\\Database\\Connection::__construct\(\) expects Closure|PDO, null given\.$#'
-          path: src/Connection.php
         - message: '#^Method Colopl\\Spanner\\Connection::selectWithOptions\(\) should return array<int, array> but returns mixed\.$#'
           path: src/Connection.php
         - message: "#^Return type \\(Generator\\<int, array, mixed, mixed\\>\\) of method Colopl\\\\Spanner\\\\Connection\\:\\:cursor\\(\\) should be compatible with return type \\(Generator\\<int, stdClass, mixed, mixed\\>\\) of method Illuminate\\\\Database\\\\Connection\\:\\:cursor\\(\\)$#"

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -108,7 +108,13 @@ class Connection extends BaseConnection
         $this->instanceId = $instanceId;
         $this->authCache = $authCache;
         $this->sessionPool = $sessionPool;
-        parent::__construct(null, $database, $tablePrefix, $config);
+        parent::__construct(
+            // TODO: throw error after v9
+            static fn() => null,
+            $database,
+            $tablePrefix,
+            $config,
+        );
     }
 
     /**


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated connection initialization method with a static closure
	- Prepared for potential future error handling improvements

Note: The changes appear to be internal and do not directly impact end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->