### PR TITLE
fix: Carbon was being altered by google/cloud-spanner

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -25,6 +25,7 @@ use Colopl\Spanner\Query\Parameterizer as QueryParameterizer;
 use Colopl\Spanner\Query\Processor as QueryProcessor;
 use Colopl\Spanner\Schema\Builder as SchemaBuilder;
 use Colopl\Spanner\Schema\Grammar as SchemaGrammar;
+use DateTimeImmutable;
 use DateTimeInterface;
 use Exception;
 use Generator;
@@ -461,7 +462,11 @@ class Connection extends BaseConnection
         // date string. Each query grammar maintains its own date string format
         // so we'll just ask the grammar for the format to get from the date.
         if ($value instanceof DateTimeInterface) {
-            return new Timestamp($value);
+            // Since Timestamp::__toString calls setTimezone() on the DateTime object,
+            // we need to clone the DateTime object to avoid changing the original object.
+            return ($value instanceof DateTimeImmutable)
+                ? new Timestamp($value)
+                : new Timestamp(DateTimeImmutable::createFromInterface($value));
         }
 
         if (is_array($value)) {

--- a/tests/ConnectionTest.php
+++ b/tests/ConnectionTest.php
@@ -631,4 +631,12 @@ class ConnectionTest extends TestCase
         $conn->useDefaultSchemaGrammar();
         $this->assertSame('test_', $conn->getSchemaGrammar()->getTablePrefix());
     }
+
+    public function test_binding_mutable_carbon_doesnt_change_timezone(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $now = now()->setTimezone('Asia/Tokyo');
+        $conn->select('SELECT ?', [$now]);
+        $this->assertSame('Asia/Tokyo', $now->getTimezone()->getName());
+    }
 }


### PR DESCRIPTION
Caused by [this](https://github.com/googleapis/google-cloud-php/blob/c5c306487e9e1732b7f22a769ce90ac2724f2de7/Core/src/TimeTrait.php#L76).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved date-time handling to ensure that original time values remain unaltered, preserving accurate timestamps and time zones during operations.
  
- **Tests**
  - Introduced validation to confirm that time zone settings are maintained when processing date-time values in requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->