### PR TITLE
Use Colopl Builder for @mixin

### DIFF
--- a/src/Eloquent/Model.php
+++ b/src/Eloquent/Model.php
@@ -17,8 +17,8 @@
 
 namespace Colopl\Spanner\Eloquent;
 
+use Colopl\Spanner\Query\Builder;
 use Illuminate\Contracts\Database\Eloquent\Builder as BuilderContract;
-use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model as BaseModel;
 use Illuminate\Database\Eloquent\Relations\Relation;
 use Illuminate\Support\Str;


### PR DESCRIPTION
Small change to help with autocomplete etc in IDEs

Since Model forwards calls to the Colopl Builder, which extends the base Laravel Builder, it makes sense to use that for the PHPDOC @mixin directive, so all features added by the Colopl builder can be autocompleted/hinted 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the internal database query handling to align with current frameworks, ensuring continued stability without affecting application functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->