### PR TITLE
Add snapshot methods to query Builder/Model

### DIFF
--- a/src/Connection.php
+++ b/src/Connection.php
@@ -625,6 +625,10 @@ class Connection extends BaseConnection
             $options['requestOptions']['requestTag'] = $tag;
         }
 
+        if (isset($options['snapshotEnabled'])) {
+            return $this->snapshot($options['snapshotTimestampBound'], fn() => $this->executeSnapshotQuery($query, $options));
+        }
+
         if ($this->inSnapshot()) {
             return $this->executeSnapshotQuery($query, $options);
         }

--- a/src/Query/Builder.php
+++ b/src/Query/Builder.php
@@ -32,6 +32,7 @@ class Builder extends BaseBuilder
     use Concerns\UsesFullTextSearch;
     use Concerns\UsesMutations;
     use Concerns\UsesPartitionedDml;
+    use Concerns\UsesSnapshots;
     use Concerns\UsesStaleReads;
 
     public const PARAMETER_LIMIT = 950;
@@ -240,6 +241,11 @@ class Builder extends BaseBuilder
 
         if ($this->dataBoostEnabled()) {
             $options['dataBoostEnabled'] = true;
+        }
+
+        if ($this->snapshotEnabled()) {
+            $options['snapshotEnabled'] = $this->snapshotEnabled();
+            $options['snapshotTimestampBound'] = $this->snapshotTimestampBound();
         }
 
         if ($this->timestampBound !== null) {

--- a/src/Query/Concerns/UsesSnapshots.php
+++ b/src/Query/Concerns/UsesSnapshots.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * Copyright 2019 Colopl Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Colopl\Spanner\Query\Concerns;
+
+use Colopl\Spanner\TimestampBound\TimestampBoundInterface;
+
+trait UsesSnapshots
+{
+    /**
+     * @var TimestampBoundInterface
+     */
+    protected $snapshotTimestampBound;
+
+    /**
+     * @param bool $toggle
+     * @return $this
+     */
+    public function snapshot(TimestampBoundInterface $timestamp): static
+    {
+        $this->snapshotTimestampBound = $timestamp;
+        return $this;
+    }
+
+    /**
+     * @return bool
+     */
+    public function snapshotEnabled(): bool
+    {
+        return isset($this->snapshotTimestampBound);
+    }
+
+    /**
+     * @return TimestampBoundInterface|null
+     */
+    public function snapshotTimestampBound(): TimestampBoundInterface|null
+    {
+        return $this->snapshotTimestampBound;
+    }
+}


### PR DESCRIPTION
As discussed in #231 this PR adds the ability to specify snapshot() when writing Eloquent queries on Models, or when using Builder directly

It can be used like so:

```php
// snapshot from a model
User::snapshot()->all();

// snapshot from a builder
DB::table('users')
    ->where('foo', 'bar')
    ->snapshot()
    ->get();
```