### PR TITLE
fix: new phpstan errors

### DIFF
--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -141,7 +141,9 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * @inheritDoc
+     * {@inheritDoc}
+     * @param array{ index_name: string }&array<string, mixed> $results
+     * @return array<array-key, string>
      */
     public function processIndexes($results)
     {
@@ -150,8 +152,10 @@ class Processor extends BaseProcessor
         }, $results);
     }
 
-    /**
-     * @inheritDoc
+    /***
+     * {@inheritDoc}
+     * @param array{key_name: string}&array<string, mixed> $results
+     * @return array<array-key, string>
      */
     public function processForeignKeys($results)
     {

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -141,9 +141,7 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * {@inheritDoc}
-     * @param array{ index_name: string }&array<string, mixed> $results
-     * @return array<array-key, string>
+     * @inheritDoc
      */
     public function processIndexes($results)
     {
@@ -152,10 +150,8 @@ class Processor extends BaseProcessor
         }, $results);
     }
 
-    /***
-     * {@inheritDoc}
-     * @param array{key_name: string}&array<string, mixed> $results
-     * @return array<array-key, string>
+    /**
+     * @inheritDoc
      */
     public function processForeignKeys($results)
     {

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -82,6 +82,27 @@ class Processor extends BaseProcessor
     }
 
     /**
+     * @inheritDoc
+     */
+    public function processTables($results)
+    {
+        return array_map(function ($result) {
+            $result = (object) $result;
+
+            return [
+                'name' => $result->name,
+                'schema' => $result->schema === '' ? $result->schema : null,
+                'schema_qualified_name' => $result->schema !== '' ? $result->schema.'.'.$result->name : $result->name,
+                'size' => isset($result->size) ? (int) $result->size : null,
+                'comment' => null,
+                'collation' => null,
+                'engine' => null,
+                'parent' => $result->parent,
+            ];
+        }, $results);
+    }
+
+    /**
      * @template TValue of mixed
      * @param TValue $value
      * @return ($value is Timestamp ? Carbon : ($value is Numeric ? string : TValue))

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -100,41 +100,27 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * Process the results of a columns query.
-     *
      * {@inheritDoc}
-     * @param array<array-key, array<array-key, mixed>> $results
-     * @return array<array-key, array{
-     *     name: string,
-     *     type_name: string,
-     *     type: string,
-     *     collation: null,
-     *     nullable: bool,
-     *     default: scalar,
-     *     auto_increment: false,
-     *     comment: null
-     * }>
+     * @param list<array{COLUMN_NAME: string, SPANNER_TYPE: string, IS_NULLABLE: string, COLUMN_DEFAULT: mixed}> $results
      */
     public function processColumns($results)
     {
         return array_map(static function (array $result) {
             return [
                 'name' => $result['COLUMN_NAME'],
-                'type_name' => preg_replace("/\([^)]+\)/", "", $result['SPANNER_TYPE']),
                 'type' => $result['SPANNER_TYPE'],
-                'collation' => null,
+                'type_name' => (string) preg_replace("/\([^)]+\)/", "", $result['SPANNER_TYPE']),
                 'nullable' => $result['IS_NULLABLE'] !== 'NO',
                 'default' => $result['COLUMN_DEFAULT'],
                 'auto_increment' => false,
+                'generation' => null,
                 'comment' => null,
             ];
         }, $results);
     }
 
     /**
-     * {@inheritDoc}
-     * @param array{ index_name: string }&array<string, mixed> $results
-     * @return array<array-key, string>
+     * @inheritDoc
      */
     public function processIndexes($results)
     {
@@ -144,9 +130,7 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * {@inheritDoc}
-     * @param array{key_name: string}&array<string, mixed> $results
-     * @return array<array-key, string>
+     * @inheritDoc
      */
     public function processForeignKeys($results)
     {

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -73,7 +73,7 @@ class Builder extends BaseBuilder
      */
     public function dropIndexIfExist($table, $name)
     {
-        if (in_array($name, $this->getIndexes($table), true)) {
+        if (in_array($name, $this->getIndexListing($table), true)) {
             $blueprint = $this->createBlueprint($table);
             $blueprint->dropIndex($name);
             $this->build($blueprint);
@@ -145,7 +145,7 @@ class Builder extends BaseBuilder
         $queries = [];
         foreach ($sortedTables as $tableData) {
             $tableName = $tableData['name'];
-            $indexes = $this->getIndexes($tableName);
+            $indexes = $this->getIndexListing($tableName);
             $blueprint = $this->createBlueprint($tableName);
             foreach ($indexes as $index) {
                 if ($index === 'PRIMARY_KEY') {

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -19,6 +19,7 @@ namespace Colopl\Spanner\Schema;
 
 use Closure;
 use Colopl\Spanner\Connection;
+use Colopl\Spanner\Query\Processor;
 use Illuminate\Database\Schema\Builder as BaseBuilder;
 
 /**
@@ -41,17 +42,15 @@ class Builder extends BaseBuilder
     public static $defaultMorphKeyType = 'uuid';
 
     /**
-     * @param null $schema
      * @inheritDoc Adds a parent key, for tracking interleaving
-     *
-     * @return list<array{ name: string, type: string, parent: string }>
+     * @return list<array{name: string, schema: string|null, schema_qualified_name: string, size: int|null, comment: string|null, collation: string|null, engine: string|null, parent: string}>
      */
     public function getTables($schema = null)
     {
-        /** @var list<array{ name: string, type: string, parent: string }> */
-        return $this->connection->select(
-            $this->grammar->compileTables(null),
-        );
+        $results = $this->connection->select($this->grammar->compileTables($schema));
+        assert(array_is_list($results));
+        /** @phpstan-ignore return.type */
+        return $this->connection->getPostProcessor()->processTables($results);
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -47,7 +47,14 @@ class Grammar extends BaseGrammar
      */
     public function compileTables($schema)
     {
-        return 'select `table_name` as name, `table_type` as type, `parent_table_name` as parent from information_schema.tables where table_schema = \'\' and table_type = \'BASE TABLE\'';
+        if ($schema === null || (is_array($schema) && count($schema) === 0)) {
+            $schema = '';
+        }
+
+        return
+            'select `table_name` as name, `table_type` as type, `parent_table_name` as parent `table_schema` as `schema` ' .
+            'from information_schema.tables where table_type = \'BASE TABLE\'' .
+            'table_schema in (' . $this->quoteString($schema) . ')';
     }
 
     /**

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -53,7 +53,7 @@ class Grammar extends BaseGrammar
 
         return
             'select `table_name` as name, `table_type` as type, `parent_table_name` as parent `table_schema` as `schema` ' .
-            'from information_schema.tables where table_type = \'BASE TABLE\'' .
+            'from information_schema.tables where table_type = \'BASE TABLE\' ' .
             'and table_schema in (' . $this->quoteString($schema) . ')';
     }
 

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -52,7 +52,7 @@ class Grammar extends BaseGrammar
         }
 
         return
-            'select `table_name` as name, `table_type` as type, `parent_table_name` as parent `table_schema` as `schema` ' .
+            'select `table_name` as name, `table_type` as type, `parent_table_name` as parent, `table_schema` as `schema` ' .
             'from information_schema.tables where table_type = \'BASE TABLE\' ' .
             'and table_schema in (' . $this->quoteString($schema) . ')';
     }

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -54,7 +54,7 @@ class Grammar extends BaseGrammar
         return
             'select `table_name` as name, `table_type` as type, `parent_table_name` as parent `table_schema` as `schema` ' .
             'from information_schema.tables where table_type = \'BASE TABLE\'' .
-            'table_schema in (' . $this->quoteString($schema) . ')';
+            'and table_schema in (' . $this->quoteString($schema) . ')';
     }
 
     /**

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -235,12 +235,12 @@ class BuilderTestLast extends TestCase
 
         $this->assertSame([
             'name' => 'id',
-            'type_name' => 'STRING',
             'type' => 'STRING(36)',
-            'collation' => null,
+            'type_name' => 'STRING',
             'nullable' => false,
             'default' => null,
             'auto_increment' => false,
+            'generation' => null,
             'comment' => null,
         ], Arr::first($sb->getColumns($table)));
     }


### PR DESCRIPTION
```
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  Line   Schema/Builder.php                                                                                                                                                                                                                                                       
 ------ ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 
  48     Return type (list<array{name: string, type: string, parent: string}>) of method Colopl\Spanner\Schema\Builder::getTables() should be compatible with return type (list<array{name: string, schema: string|null, schema_qualified_name: string, size: int|null, comment:  
         string|null, collation: string|null, engine: string|null}>) of method Illuminate\Database\Schema\Builder::getTables()                                                                                                                                                    
         🪪  method.childReturnType                                                                                                                                                                                                                                               
  75     Call to function in_array() with arguments string, list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}> and true will always evaluate to false.  
         🪪  function.impossibleType                                                                                                                                                             
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.                                              
  150    Strict comparison using === between array{name: string, columns: list<string>, type: string, unique: bool, primary: bool} and 'PRIMARY_KEY' will always evaluate to false.              
         🪪  identical.alwaysFalse                                                                                                                                                               
         💡 Because the type is coming from a PHPDoc, you can turn off this check by setting treatPhpDocTypesAsCertain: false in your phpstan.neon.                                              
 ------ ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- 


```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for processing and standardizing table metadata, including schema and size details.
  - Enhanced table retrieval to allow optional schema filtering.

- **Improvements**
  - Table and column metadata now includes additional and more consistently formatted fields, including a new generation attribute for columns.
  - Table listing queries now support schema-based filtering for more precise results.

- **Documentation**
  - Improved and simplified internal documentation for better clarity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->