### PR TITLE
fix!: SchemaBuilder::getIndexes was returning incorrect values

### DIFF
--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -123,8 +123,8 @@ class Processor extends BaseProcessor
 
     /**
      * {@inheritDoc}
-     * @param list<array<string, mixed>> $results
-     * @return list<array{name: string, columns: list<string>, foreign_schema: string, foreign_table: string, foreign_columns: list<string>, on_update: string, on_delete: string}>
+     * @param array{key_name: string}&array<string, mixed> $results
+     * @return array<array-key, string>
      */
     public function processForeignKeys($results)
     {

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -103,20 +103,28 @@ class Processor extends BaseProcessor
 
     /**
      * {@inheritDoc}
-     * @param array{ index_name: string }&array<string, mixed> $results
-     * @return array<array-key, string>
+     * @param list<array<string, mixed>> $results
+     * @return list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}>
      */
     public function processIndexes($results)
     {
         return array_map(function ($result) {
-            return ((object) $result)->index_name;
+            $result = (object) $result;
+
+            return [
+                'name' => $name = $result->name,
+                'columns' => $result->columns ? explode(',', $result->columns) : [],
+                'type' => strtolower($result->type),
+                'unique' => (bool) $result->unique,
+                'primary' => $name === 'PRIMARY_KEY',
+            ];
         }, $results);
     }
 
     /**
      * {@inheritDoc}
-     * @param array{key_name: string}&array<string, mixed> $results
-     * @return array<array-key, string>
+     * @param list<array<string, mixed>> $results
+     * @return list<array{name: string, columns: list<string>, foreign_schema: string, foreign_table: string, foreign_columns: list<string>, on_update: string, on_delete: string}>
      */
     public function processForeignKeys($results)
     {

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -144,7 +144,7 @@ class Builder extends BaseBuilder
         $queries = [];
         foreach ($sortedTables as $tableData) {
             $tableName = $tableData['name'];
-            $indexes = $this->getIndexes($tableName);
+            $indexes = $this->getIndexListing($tableName);
             $blueprint = $this->createBlueprint($tableName);
             foreach ($indexes as $index) {
                 if ($index === 'PRIMARY_KEY') {

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -57,10 +57,20 @@ class Grammar extends BaseGrammar
      */
     public function compileIndexes($table)
     {
-        return sprintf(
-            'select index_name as `index_name` from information_schema.indexes where table_schema = \'\' and table_name = %s',
-            $this->quoteString($table),
-        );
+        return implode(' ', [
+            'select',
+            implode(', ', [
+                'i.index_name as `name`',
+                'string_agg(c.column_name, \',\') as `columns`',
+                'i.index_type as `type`',
+                'i.is_unique as `unique`',
+            ]),
+            'from information_schema.indexes as i',
+            'join information_schema.index_columns as c on i.table_schema = c.table_schema and i.table_name = c.table_name and i.index_name = c.index_name',
+            'where i.table_schema = ' . $this->quoteString(''),
+            'and i.table_name = ' . $this->quoteString($table),
+            'group by i.index_name, i.index_type, i.is_unique',
+        ]);
     }
 
     /**

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -256,7 +256,7 @@ class BuilderTestLast extends TestCase
             $table->primary('id');
         });
 
-        $this->assertSame([$table], $sb->getTableListing());
+        $this->assertContains($table, $sb->getTableListing());
     }
 
     public function test_getIndexes(): void

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -245,7 +245,7 @@ class BuilderTestLast extends TestCase
         ], Arr::first($sb->getColumns($table)));
     }
 
-    public function test_getAllTables(): void
+    public function test_getTableListing(): void
     {
         $conn = $this->getDefaultConnection();
         $sb = $conn->getSchemaBuilder();
@@ -256,14 +256,53 @@ class BuilderTestLast extends TestCase
             $table->primary('id');
         });
 
-        /** @var array{ name: string, type: string } $row */
-        $row = Arr::first(
-            $sb->getTables(),
-            static fn(array $row): bool => $row['name'] === $table,
-        );
+        $this->assertSame([$table], $sb->getTableListing());
+    }
 
-        $this->assertSame($table, $row['name']);
-        $this->assertSame('BASE TABLE', $row['type']);
+    public function test_getIndexes(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $sb = $conn->getSchemaBuilder();
+        $table = $this->generateTableName(class_basename(__CLASS__));
+        $sb->create($table, function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('something');
+            $table->index('something');
+        });
+
+        $this->assertSame([
+            [
+                'name' => strtolower($table) . '_something_index',
+                'columns' => ['something'],
+                'type' => 'index',
+                'unique' => false,
+                'primary' => false,
+            ],
+            [
+                'name' => 'PRIMARY_KEY',
+                'columns' => ['id'],
+                'type' => 'primary_key',
+                'unique' => true,
+                'primary' => true,
+            ],
+        ], $sb->getIndexes($table));
+    }
+
+    public function test_getIndexListing(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $sb = $conn->getSchemaBuilder();
+        $table = $this->generateTableName(class_basename(__CLASS__));
+        $sb->create($table, function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('something');
+            $table->index('something');
+        });
+
+        $this->assertSame([
+            strtolower($table) . '_something_index',
+            'PRIMARY_KEY',
+        ], $sb->getIndexListing($table));
     }
 
     public function test_dropAllTables(): void


### PR DESCRIPTION
Was only returning the index name (also with wrong key name).
It should be returning more data.
This fix will align it with other database drivers.

Also, dropAllTables was probably not working correctly, so that was fixed as well.