### PR TITLE
fix: phpstan errors

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,7 @@ RUN pecl_mt_install() { \
   && apk add --no-cache bash gmp libxml2 libstdc++ \
   && apk add --no-cache --virtual=.build-deps autoconf curl-dev gcc gmp-dev g++ libxml2-dev linux-headers make pcre-dev tzdata \
   && docker-php-ext-install -j$(nproc) bcmath gmp \
-  && pecl_mt_install protobuf \
+  && pecl_mt_install protobuf-4.30.2 \
   && pecl_mt_install grpc \
   && pecl_mt_install pcov \
   && docker-php-ext-enable grpc opcache protobuf \

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -6,3 +6,14 @@ parameters:
         - message: "#^Call to an undefined method Illuminate\\\\Database\\\\ConnectionInterface\\:\\:recordsHaveBeenModified\\(\\)\\.$#"
           count: 1
           path: src/Query/Processor.php
+        -
+            message: '#^Closure invoked with 2 parameters, 3 required\.$#'
+            identifier: arguments.count
+            count: 1
+            path: src/Schema/Builder.php
+
+        -
+            message: '#^Parameter \#2 of closure expects Closure, Closure\|null given\.$#'
+            identifier: argument.type
+            count: 1
+            path: src/Schema/Builder.php

--- a/src/Query/Processor.php
+++ b/src/Query/Processor.php
@@ -100,9 +100,7 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * {@inheritDoc}
-     * @param list<array<string, mixed>> $results
-     * @return list<array{name: string, schema: string|null, size: int|null, comment: string|null, collation: string|null, engine: string|null, parent: string|null}>
+     * @inheritDoc
      */
     public function processTables($results)
     {
@@ -112,6 +110,9 @@ class Processor extends BaseProcessor
             return [
                 'name' => $result->name,
                 'schema' => $result->schema !== '' ? $result->schema : null,
+                'schema_qualified_name' => $result->schema !== ''
+                    ? $result->schema . '.' . $result->name
+                    : $result->name,
                 'parent' => $result->parent,
                 'size' => null,
                 'comment' => null,
@@ -122,11 +123,7 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * Process the results of a columns query.
-     *
-     * {@inheritDoc}
-     * @param list<array<string, mixed>> $results
-     * @return list<array{name: string, type: string, type_name: string, nullable: bool, collation: null, default: mixed, auto_increment: false, comment: null, generation: null}>
+     * @inheritDoc
      */
     public function processColumns($results)
     {
@@ -149,9 +146,7 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * {@inheritDoc}
-     * @param list<array<string, mixed>> $results
-     * @return list<array{name: string, columns: list<string>, type: string, unique: bool, primary: bool}>
+     * @inheritDoc
      */
     public function processIndexes($results)
     {
@@ -169,9 +164,7 @@ class Processor extends BaseProcessor
     }
 
     /**
-     * {@inheritDoc}
-     * @param list<array<string, mixed>> $results
-     * @return list<array{name: string, columns: list<string>, foreign_schema: string, foreign_table: string, foreign_columns: list<string>, on_update: string, on_delete: string}>
+     * @inheritDoc
      */
     public function processForeignKeys($results)
     {

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -41,20 +41,6 @@ class Builder extends BaseBuilder
     public static $defaultMorphKeyType = 'uuid';
 
     /**
-     * @param null $schema
-     * @inheritDoc Adds a parent key, for tracking interleaving
-     *
-     * @return list<array{ name: string, type: string, parent: string }>
-     */
-    public function getTables($schema = null)
-    {
-        /** @var list<array{ name: string, type: string, parent: string }> */
-        return $this->connection->select(
-            $this->grammar->compileTables(null),
-        );
-    }
-
-    /**
      * @param string $table
      * @param string $name
      * @return void
@@ -134,7 +120,7 @@ class Builder extends BaseBuilder
             $foreigns = $this->getForeignKeys($tableName);
             $blueprint = $this->createBlueprint($tableName);
             foreach ($foreigns as $foreign) {
-                $blueprint->dropForeign($foreign);
+                $blueprint->dropForeign($foreign['name']);
             }
             array_push($queries, ...$blueprint->toSql());
         }

--- a/src/Schema/Builder.php
+++ b/src/Schema/Builder.php
@@ -59,7 +59,7 @@ class Builder extends BaseBuilder
      */
     public function dropIndexIfExist($table, $name)
     {
-        if (in_array($name, $this->getIndexes($table), true)) {
+        if (in_array($name, $this->getIndexListing($table), true)) {
             $blueprint = $this->createBlueprint($table);
             $blueprint->dropIndex($name);
             $this->build($blueprint);
@@ -71,7 +71,6 @@ class Builder extends BaseBuilder
      */
     protected function createBlueprint($table, ?Closure $callback = null)
     {
-        /** @phpstan-ignore isset.property */
         return isset($this->resolver)
             ? ($this->resolver)($table, $callback)
             : new Blueprint($this->connection, $table, $callback);
@@ -83,6 +82,17 @@ class Builder extends BaseBuilder
     public function dropAllTables()
     {
         $connection = $this->connection;
+        /** @var list<array{
+         *     name: string,
+         *     schema: string|null,
+         *     schema_qualified_name: string,
+         *     size: int|null,
+         *     comment: string|null,
+         *     collation: string|null,
+         *     engine: string|null,
+         *     parent: string|null
+         * }> $tables
+         */
         $tables = $this->getTables();
 
         if (count($tables) === 0) {

--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -47,7 +47,38 @@ class Grammar extends BaseGrammar
      */
     public function compileTables($schema)
     {
-        return 'select `table_name` as name, `table_type` as type, `parent_table_name` as parent from information_schema.tables where table_schema = \'\' and table_type = \'BASE TABLE\'';
+        return implode(' ', [
+            'select',
+            implode(', ', [
+                'table_name as name',
+                'table_schema as `schema`',
+                'parent_table_name as parent',
+            ]),
+            'from information_schema.tables',
+            'where table_type = \'BASE TABLE\'',
+            'and table_schema = \'\'',
+        ]);
+    }
+
+    /**
+     * Compile the query to determine the columns.
+     *
+     * @param string $table
+     * @return string
+     */
+    public function compileColumns($schema, $table)
+    {
+        return implode(' ', [
+            'select',
+            implode(', ', [
+                'column_name as `name`',
+                'spanner_type as `type`',
+                'is_nullable as `nullable`',
+                'column_default as `default`',
+            ]),
+            'from information_schema.columns',
+            'where table_name = ' . $this->quoteString($table),
+        ]);
     }
 
     /**
@@ -84,25 +115,24 @@ class Grammar extends BaseGrammar
      */
     public function compileForeignKeys($schema, $table)
     {
-        return sprintf(
-            'select constraint_name as `key_name` from information_schema.table_constraints where constraint_type = "FOREIGN KEY" and table_schema = \'\' and table_name = %s',
-            $this->quoteString($table),
-        );
-    }
-
-    /**
-     * Compile the query to determine the columns.
-     *
-     * @param string|null $schema
-     * @param $table
-     * @return string
-     */
-    public function compileColumns($schema, $table)
-    {
-        return sprintf(
-            'select * from information_schema.columns where table_schema = \'\' and table_name = %s',
-            $this->quoteString($table),
-        );
+        return implode(' ', [
+            'select',
+            implode(', ', [
+                'kc.constraint_name as `name`',
+                'string_agg(kc.column_name) as `columns`',
+                'cc.table_schema as `foreign_schema`',
+                'cc.table_name as `foreign_table`',
+                'string_agg(cc.column_name) as `foreign_columns`',
+                'rc.update_rule as `on_update`',
+                'rc.delete_rule as `on_delete`',
+            ]),
+            'from information_schema.key_column_usage kc',
+            'join information_schema.referential_constraints rc on kc.constraint_name = rc.constraint_name',
+            'join information_schema.constraint_column_usage cc on kc.constraint_name = cc.constraint_name',
+            'where kc.table_schema = ""',
+            'and kc.table_name = ' . $this->quoteString($table),
+            'group by kc.constraint_name, cc.table_schema, cc.table_name, rc.update_rule, rc.delete_rule'
+        ]);
     }
 
     /**

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -218,6 +218,7 @@ class BuilderTestLast extends TestCase
         $this->assertSame([
             'name' => $table,
             'schema' => null,
+            'schema_qualified_name' => $table,
             'parent' => null,
             'size' => null,
             'comment' => null,

--- a/tests/Schema/BuilderTestLast.php
+++ b/tests/Schema/BuilderTestLast.php
@@ -213,35 +213,62 @@ class BuilderTestLast extends TestCase
             $table->primary('id');
         });
 
-        /** @var array{ name: string, type: string } $row */
-        $row = Arr::first(
-            $sb->getTables(),
-            static fn(array $row): bool => $row['name'] === $table,
-        );
+        $row = Arr::first($sb->getTables(), fn ($row) => $row['name'] === $table);
 
-        $this->assertSame($table, $row['name']);
+        $this->assertSame([
+            'name' => $table,
+            'schema' => null,
+            'parent' => null,
+            'size' => null,
+            'comment' => null,
+            'collation' => null,
+            'engine' => null,
+        ], $row);
     }
 
-    public function test_getColumns(): void
+    public function test_getColumns_with_nullable(): void
     {
         $conn = $this->getDefaultConnection();
         $sb = $conn->getSchemaBuilder();
         $table = $this->generateTableName(class_basename(__CLASS__));
 
         $sb->create($table, function (Blueprint $table) {
-            $table->uuid('id');
-            $table->primary('id');
+            $table->integer('id')->nullable()->primary();
+        });
+
+        $this->assertSame([
+            'name' => 'id',
+            'type_name' => 'INT64',
+            'type' => 'INT64',
+            'collation' => null,
+            'nullable' => true,
+            'default' => null,
+            'auto_increment' => false,
+            'comment' => null,
+            'generation' => null,
+        ], Arr::first($sb->getColumns($table)));
+    }
+
+    public function test_getColumns_with_default(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $sb = $conn->getSchemaBuilder();
+        $table = $this->generateTableName(class_basename(__CLASS__));
+
+        $sb->create($table, function (Blueprint $table) {
+            $table->string('id', 1)->default('a')->primary();
         });
 
         $this->assertSame([
             'name' => 'id',
             'type_name' => 'STRING',
-            'type' => 'STRING(36)',
+            'type' => 'STRING(1)',
             'collation' => null,
             'nullable' => false,
-            'default' => null,
+            'default' => '"a"',
             'auto_increment' => false,
             'comment' => null,
+            'generation' => null,
         ], Arr::first($sb->getColumns($table)));
     }
 
@@ -303,6 +330,36 @@ class BuilderTestLast extends TestCase
             strtolower($table) . '_something_index',
             'PRIMARY_KEY',
         ], $sb->getIndexListing($table));
+    }
+
+    public function test_getForeignKeys(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $sb = $conn->getSchemaBuilder();
+        $table1 = $this->generateTableName(class_basename(__CLASS__). '_1');
+        $sb->create($table1, function (Blueprint $table) {
+            $table->uuid('id')->primary();
+            $table->uuid('something');
+            $table->index('something');
+        });
+
+        $table2 = $this->generateTableName(class_basename(__CLASS__). '_2');
+        $sb->create($table2, function (Blueprint $table) use ($table1) {
+            $table->uuid('table2_id')->primary();
+            $table->uuid('other_id');
+            $table->index('other_id');
+            $table->foreign('other_id')->references('id')->on($table1);
+        });
+
+        $this->assertSame([[
+            'name' => strtolower($table2) . '_other_id_foreign',
+            'columns' => ['other_id'],
+            'foreign_schema' => '',
+            'foreign_table' => $table1,
+            'foreign_columns' => ['id'],
+            'on_update' => "no action",
+            'on_delete' => "no action",
+        ]], $sb->getForeignKeys($table2));
     }
 
     public function test_dropAllTables(): void


### PR DESCRIPTION
Merging 8.x fixes and also fix laravel 12 specific errors in [62bc09e](https://github.com/colopl/laravel-spanner/pull/281/commits/62bc09e47e90e5c2775b444bfaf470dd26e57899).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced schema metadata retrieval to provide detailed information for tables, columns, indexes, and foreign keys.
- **Bug Fixes**
  - Improved handling of nullable columns and default values in schema processing.
- **Refactor**
  - Standardized data processing by using object properties and expanded returned metadata structures.
- **Tests**
  - Added and updated tests to verify detailed column and foreign key metadata.
- **Chores**
  - Updated static analysis configuration and Dockerfile for improved stability and compatibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->