### PR TITLE
feat: Allow alter change stream to alter tables

### DIFF
--- a/src/Schema/Grammar.php
+++ b/src/Schema/Grammar.php
@@ -420,16 +420,18 @@ class Grammar extends BaseGrammar
     /**
      * @param Blueprint $blueprint
      * @param ChangeStreamDefinition $command
-     * @return string
+     * @return list<string>
      */
-    public function compileAlterChangeStream(Blueprint $blueprint, ChangeStreamDefinition $command): string
+    public function compileAlterChangeStream(Blueprint $blueprint, ChangeStreamDefinition $command): array
     {
         $parts = [];
-        $parts[] = "alter change stream {$this->wrap($command->stream)}";
-        if ($command->getOptions() !== []) {
-            $parts[] = 'set ' . $this->formatChangeStreamOptions($command);
+        if ($command->tables !== []) {
+            $parts[] = "alter change stream {$this->wrap($command->stream)} set {$this->formatChangeStreamTables($command)}";
         }
-        return implode(' ', $parts);
+        if ($command->getOptions() !== []) {
+            $parts[] = "alter change stream {$this->wrap($command->stream)} set {$this->formatChangeStreamOptions($command)}";
+        }
+        return $parts;
     }
 
     /**

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -831,16 +831,20 @@ class BlueprintTest extends TestCase
         $blueprint = new Blueprint($conn, $tableName);
         $blueprint->uuid('id')->primary();
         $blueprint->create();
-        $blueprint->createChangeStream($streamName)->for($blueprint->getTable())->excludeTtlDeletes(true);
+        $blueprint->createChangeStream($streamName)
+            ->for($blueprint->getTable())
+            ->excludeTtlDeletes(true);
         $blueprint->build();
 
         $blueprint = new Blueprint($conn, '');
         $blueprint->alterChangeStream($streamName)
+            ->for($tableName)
             ->excludeTtlDeletes(false)
             ->retentionPeriod('7d');
         $blueprint->build();
 
         $this->assertSame([
+            "alter change stream `$streamName` set for `{$tableName}`",
             "alter change stream `$streamName` set options (retention_period='7d', exclude_ttl_deletes=false)",
         ], $blueprint->toSql());
 


### PR DESCRIPTION
Altering tables was always supported in Spanner but was never implemented.