### PR TITLE
feat: don't wait a whole second for DDL polling when using emulator

### DIFF
--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -96,10 +96,19 @@ trait ManagesDataDefinitions
      */
     protected function waitForOperation(LongRunningOperation $operation): mixed
     {
-        $result = $operation->pollUntilComplete(['maxPollingDurationSeconds' => 0.0]);
+        $options = [];
+        $options['maxPollingDurationSeconds'] = 0.0;
+
+        if (getenv('SPANNER_EMULATOR_HOST')) {
+            $options['pollingIntervalSeconds'] = 0.001;
+        }
+
+        $result = $operation->pollUntilComplete($options);
+
         if ($operation->error() !== null) {
             throw new RuntimeException((string) json_encode($operation->error()));
         }
+
         return $result;
     }
 }

--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -97,7 +97,6 @@ trait ManagesDataDefinitions
     protected function waitForOperation(LongRunningOperation $operation): mixed
     {
         $options = [];
-        $options['maxPollingDurationSeconds'] = 0.0;
 
         if (getenv('SPANNER_EMULATOR_HOST')) {
             $options['pollingIntervalSeconds'] = 0.001;


### PR DESCRIPTION
DDL's take a long time to complete on normal Spanner so it makes sense to wait a second before completion.
This does not make sense when using the emulator because the emulator responds to the DDL almost instantly.

