### PR TITLE
fix: incorrect index name when index specifies order

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.env
 /.idea
 /.phpunit.cache
+/.php-cs-fixer.cache
 /coverage
 /vendor
 /composer.lock

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -489,7 +489,7 @@ class Blueprint extends BaseBlueprint
 
     /**
      * @inheritDoc
-     * @param list<string> $columns
+     * @param array<string, string>|list<string> $columns
      */
     protected function createIndexName($type, array $columns)
     {

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -464,7 +464,7 @@ class Blueprint extends BaseBlueprint
 
     /**
      * @inheritDoc
-     * @param string|list<string> $columns
+     * @param string|array<string, string>|list<string> $columns
      * @return IndexDefinition
      */
     protected function indexCommand($type, $columns, $index, $algorithm = null, $operatorClass = null)

--- a/src/Schema/Blueprint.php
+++ b/src/Schema/Blueprint.php
@@ -501,7 +501,8 @@ class Blueprint extends BaseBlueprint
             $table = $this->connection->getTablePrefix() . $table;
         }
 
-        $index = strtolower($table . '_' . implode('_', $columns) . '_' . $type);
+        $columnNames = array_is_list($columns) ? $columns : array_keys($columns);
+        $index = strtolower($table . '_' . implode('_', $columnNames) . '_' . $type);
 
         if ($type !== 'foreign' && $schema !== null) {
             $index = $schema . '.' . $index;

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -234,12 +234,16 @@ class BlueprintTest extends TestCase
         $blueprint = new Blueprint($conn, $tableName, function (Blueprint $table) {
             $table->unique('name');
             $table->index('createdAt');
+            $table->index(['name', 'createdAt']);
+            $table->index(['name' => 'asc', 'createdAt' => 'desc']);
         });
 
         $statements = $blueprint->toSql();
         $this->assertSame([
             "create unique index `{$indexPrefix}_name_unique` on `{$tableName}` (`name`)",
             "create index `{$indexPrefix}_createdat_index` on `{$tableName}` (`createdAt`)",
+            "create index `{$indexPrefix}_name_createdat_index` on `{$tableName}` (`name`, `createdAt`)",
+            "create index `{$indexPrefix}_name_createdat_index` on `{$tableName}` (`name` asc, `createdAt` desc)",
         ], $statements);
     }
 

--- a/tests/Schema/BlueprintTest.php
+++ b/tests/Schema/BlueprintTest.php
@@ -235,7 +235,6 @@ class BlueprintTest extends TestCase
             $table->unique('name');
             $table->index('createdAt');
             $table->index(['name', 'createdAt']);
-            $table->index(['name' => 'asc', 'createdAt' => 'desc']);
         });
 
         $statements = $blueprint->toSql();
@@ -243,6 +242,20 @@ class BlueprintTest extends TestCase
             "create unique index `{$indexPrefix}_name_unique` on `{$tableName}` (`name`)",
             "create index `{$indexPrefix}_createdat_index` on `{$tableName}` (`createdAt`)",
             "create index `{$indexPrefix}_name_createdat_index` on `{$tableName}` (`name`, `createdAt`)",
+        ], $statements);
+    }
+
+    public function test_create_indexes_with_order(): void
+    {
+        $conn = $this->getDefaultConnection();
+        $tableName = $this->generateTableName();
+        $indexPrefix = Str::snake($tableName);
+        $blueprint = new Blueprint($conn, $tableName, function (Blueprint $table) {
+            $table->index(['name' => 'asc', 'createdAt' => 'desc']);
+        });
+
+        $statements = $blueprint->toSql();
+        $this->assertSame([
             "create index `{$indexPrefix}_name_createdat_index` on `{$tableName}` (`name` asc, `createdAt` desc)",
         ], $statements);
     }


### PR DESCRIPTION
This pull request improves the way index names are generated in the schema blueprint, ensuring consistent naming regardless of whether columns are specified as a list or an associative array. It also updates the corresponding tests to cover these scenarios.

Index name generation improvements:

* Modified `createIndexName` in `Blueprint.php` to use the correct column names when columns are provided as an associative array (e.g., with sort directions), ensuring index names are generated consistently.

Test coverage enhancements:

* Updated `BlueprintTest.php` to add test cases for creating indexes with both simple column lists and associative arrays specifying sort directions, verifying the new index name logic.