### PR TITLE
feat: Clear session when dropping a database

### DIFF
--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -20,6 +20,7 @@ namespace Colopl\Spanner\Concerns;
 
 use Google\Cloud\Core\LongRunning\LongRunningOperation;
 use Google\Cloud\Spanner\Database;
+use Psr\Cache\CacheItemPoolInterface;
 use RuntimeException;
 use function json_encode;
 
@@ -29,6 +30,11 @@ trait ManagesDataDefinitions
      * @return Database
      */
     abstract public function getSpannerDatabase(): Database;
+
+    /**
+     * @return CacheItemPoolInterface|null
+     */
+    abstract protected function getSessionCache(): ?CacheItemPoolInterface;
 
     /**
      * @param list<string> $statements
@@ -69,8 +75,6 @@ trait ManagesDataDefinitions
             $database->create(['statements' => $statements]),
         );
 
-        $database->session()->refresh();
-
         foreach ($statements as $statement) {
             $this->logQuery($statement, [], $this->getElapsedTime($start));
         }
@@ -82,6 +86,7 @@ trait ManagesDataDefinitions
     public function dropDatabase()
     {
         $this->getSpannerDatabase()->drop();
+        $this->getSessionCache()?->clear();
     }
 
     /**

--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -63,10 +63,13 @@ trait ManagesDataDefinitions
     public function createDatabase(array $statements = [])
     {
         $start = microtime(true);
+        $database = $this->getSpannerDatabase();
 
         $this->waitForOperation(
-            $this->getSpannerDatabase()->create(['statements' => $statements]),
+            $database->create(['statements' => $statements]),
         );
+
+        $database->session()->refresh();
 
         foreach ($statements as $statement) {
             $this->logQuery($statement, [], $this->getElapsedTime($start));

--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -37,6 +37,11 @@ trait ManagesDataDefinitions
     abstract protected function getSessionCache(): ?CacheItemPoolInterface;
 
     /**
+     * @return void
+     */
+    abstract public function disconnect();
+
+    /**
      * @param list<string> $statements
      * @return mixed
      */
@@ -87,6 +92,7 @@ trait ManagesDataDefinitions
     {
         $this->getSpannerDatabase()->drop();
         $this->getSessionCache()?->clear();
+        $this->disconnect();
     }
 
     /**

--- a/src/Concerns/ManagesDataDefinitions.php
+++ b/src/Concerns/ManagesDataDefinitions.php
@@ -91,7 +91,11 @@ trait ManagesDataDefinitions
     public function dropDatabase()
     {
         $this->getSpannerDatabase()->drop();
+
+        // Clear the session cache to avoid using invalidated session.
         $this->getSessionCache()?->clear();
+
+        // Disconnect to avoid using a dropped database connection.
         $this->disconnect();
     }
 

--- a/src/Connection.php
+++ b/src/Connection.php
@@ -137,6 +137,14 @@ class Connection extends BaseConnection
     }
 
     /**
+     * @return CacheItemPoolInterface|null
+     */
+    protected function getSessionCache(): ?CacheItemPoolInterface
+    {
+        return $this->sessionCache;
+    }
+
+    /**
      * @deprecated will be removed in v10
      * @return Database|Transaction
      */

--- a/tests/Concerns/ManagesDataDefinitionsTest.php
+++ b/tests/Concerns/ManagesDataDefinitionsTest.php
@@ -20,7 +20,6 @@ namespace Colopl\Spanner\Tests\Concerns;
 
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Tests\TestCase;
-use Google\Cloud\Spanner\V1\Session;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
@@ -91,8 +90,7 @@ class ManagesDataDefinitionsTest extends TestCase
         $events = Event::fake([QueryExecuted::class]);
         $config = config('database.connections.main');
         $database = 'test_' . time();
-        $sessionCache = new ArrayAdapter();
-        $conn = new Connection($config['instance'], $database, '', $config, null, $sessionCache);
+        $conn = new Connection($config['instance'], $database, '', $config);
 
         if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
             $this->setUpEmulatorInstance($conn);
@@ -106,18 +104,32 @@ class ManagesDataDefinitionsTest extends TestCase
             range(0, 1),
         );
 
-        $this->assertSame([], $sessionCache->getValues(), 'No session should exist before the database is created.');
-
         $conn->createDatabase($statements);
 
         $this->assertSame($statements[0], $conn->getQueryLog()[0]['query']);
         $this->assertSame($statements[1], $conn->getQueryLog()[1]['query']);
         $this->assertCount(2, $conn->getQueryLog());
         $events->assertDispatchedTimes(QueryExecuted::class, 2);
+    }
 
-        // createDatabase() must refresh the session, so a session for the new database
-        // must be created and cached without running any query.
-        $cachedSessions = $sessionCache->getValues();
-        $this->assertCount(1, $cachedSessions, 'Session must be refreshed right after the database is created.');
+    public function test_dropDatabase_clears_session_cache(): void
+    {
+        $config = config('database.connections.main');
+        $database = 'test_' . time() . '_' . Str::lower(Str::random(5));
+        $sessionCache = new ArrayAdapter();
+        $conn = new Connection($config['instance'], $database, '', $config, null, $sessionCache);
+
+        if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
+            $this->setUpEmulatorInstance($conn);
+        }
+
+        $conn->createDatabase();
+        $conn->refreshSession();
+
+        $this->assertNotSame([], $sessionCache->getValues(), 'A session should be cached before the database is dropped.');
+
+        $conn->dropDatabase();
+
+        $this->assertSame([], $sessionCache->getValues(), 'Session cache must be cleared after the database is dropped.');
     }
 }

--- a/tests/Concerns/ManagesDataDefinitionsTest.php
+++ b/tests/Concerns/ManagesDataDefinitionsTest.php
@@ -131,5 +131,10 @@ class ManagesDataDefinitionsTest extends TestCase
         $conn->dropDatabase();
 
         $this->assertSame([], $sessionCache->getValues(), 'Session cache must be cleared after the database is dropped.');
+
+        $conn->createDatabase();
+        $conn->refreshSession();
+
+        $this->assertNotSame([], $sessionCache->getValues(), 'Session cache should be recreated when reusing the same connection after dropping and recreating the database.');
     }
 }

--- a/tests/Concerns/ManagesDataDefinitionsTest.php
+++ b/tests/Concerns/ManagesDataDefinitionsTest.php
@@ -20,9 +20,11 @@ namespace Colopl\Spanner\Tests\Concerns;
 
 use Colopl\Spanner\Connection;
 use Colopl\Spanner\Tests\TestCase;
+use Google\Cloud\Spanner\V1\Session;
 use Illuminate\Database\Events\QueryExecuted;
 use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Str;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 class ManagesDataDefinitionsTest extends TestCase
 {
@@ -39,14 +41,15 @@ class ManagesDataDefinitionsTest extends TestCase
         $this->assertSame([], $result);
         $this->assertSame($statement, $conn->getQueryLog()[0]['query']);
         $this->assertCount(1, $conn->getQueryLog());
-        Event::assertDispatchedTimes(QueryExecuted::class, 1);
+        $events->assertDispatchedTimes(QueryExecuted::class, 1);
         $this->assertContains($newTable, array_map(fn($d) => $d['name'], $conn->getSchemaBuilder()->getTables()));
     }
 
     public function test_runDdlBatch_within_pretend(): void
     {
+        $events = Event::fake([QueryExecuted::class]);
         $conn = $this->getDefaultConnection();
-        $conn->setEventDispatcher(Event::fake([QueryExecuted::class]));
+        $conn->setEventDispatcher($events);
         $conn->enableQueryLog();
 
         $newTable = $this->generateTableName('runDdlBatch');
@@ -65,7 +68,7 @@ class ManagesDataDefinitionsTest extends TestCase
             'readWriteType' => null,
         ]], $conn->getQueryLog());
 
-        Event::assertDispatchedTimes(QueryExecuted::class, 1);
+        $events->assertDispatchedTimes(QueryExecuted::class, 1);
 
         $this->assertFalse($conn->getSchemaBuilder()->hasTable($newTable));
     }
@@ -80,15 +83,16 @@ class ManagesDataDefinitionsTest extends TestCase
 
         $this->assertSame([], $result);
         $this->assertCount(0, $conn->getQueryLog());
-        Event::assertNotDispatched(QueryExecuted::class);
+        $events->assertNotDispatched(QueryExecuted::class);
     }
 
     public function test_createDatabase_with_statements(): void
     {
         $events = Event::fake([QueryExecuted::class]);
-
         $config = config('database.connections.main');
-        $conn = new Connection($config['instance'], 'test_' . time(), '', $config);
+        $database = 'test_' . time();
+        $sessionCache = new ArrayAdapter();
+        $conn = new Connection($config['instance'], $database, '', $config, null, $sessionCache);
 
         if (!empty(getenv('SPANNER_EMULATOR_HOST'))) {
             $this->setUpEmulatorInstance($conn);
@@ -101,11 +105,19 @@ class ManagesDataDefinitionsTest extends TestCase
             static fn() => "create table " . 'createDatabase_' . md5(uniqid('', true)) . " (id int64) primary key (id)",
             range(0, 1),
         );
+
+        $this->assertSame([], $sessionCache->getValues(), 'No session should exist before the database is created.');
+
         $conn->createDatabase($statements);
+
         $this->assertSame($statements[0], $conn->getQueryLog()[0]['query']);
         $this->assertSame($statements[1], $conn->getQueryLog()[1]['query']);
         $this->assertCount(2, $conn->getQueryLog());
+        $events->assertDispatchedTimes(QueryExecuted::class, 2);
 
-        Event::assertDispatchedTimes(QueryExecuted::class, 2);
+        // createDatabase() must refresh the session, so a session for the new database
+        // must be created and cached without running any query.
+        $cachedSessions = $sessionCache->getValues();
+        $this->assertCount(1, $cachedSessions, 'Session must be refreshed right after the database is created.');
     }
 }


### PR DESCRIPTION
The old session will throw an error when attempting to use it after dropping a database so it's best to clear it when the database is cleared.